### PR TITLE
fix: prevent duplicate keys in MetadatumMap arbitrary generator

### DIFF
--- a/packages/evolution/src/core/TransactionMetadatum.ts
+++ b/packages/evolution/src/core/TransactionMetadatum.ts
@@ -258,12 +258,15 @@ export const arbitrary: FastCheck.Arbitrary<TransactionMetadatum> = FastCheck.on
     ),
     { maxLength: 3 }
   ).map((value) => new ArrayMetadatum({ value })),
-  FastCheck.array(
+  FastCheck.uniqueArray(
     FastCheck.tuple(
       FastCheck.string().map((value) => new TextMetadatum({ value })),
       int64Arbitrary.map((value) => new IntMetadatum({ value }))
     ),
-    { maxLength: 3 }
+    {
+      maxLength: 3,
+      selector: ([key]) => key.value // Ensure unique keys by their string value
+    }
   ).map((entries) => {
     const map = new Map()
     for (const [key, value] of entries) {


### PR DESCRIPTION
The property-based test generator for MetadatumMap was creating invalid metadata by allowing duplicate keys (e.g., two empty strings). When duplicate keys were added to the Map, the second insertion would overwrite the first, causing a mismatch between the expected array length and actual Map size.

This caused flaky test failures in AuxiliaryData.CML.test.ts when comparing Evolution SDK CBOR output with CML CBOR output.

Fixed by using FastCheck.uniqueArray with a selector function that ensures unique keys based on their string values.

Fixes intermittent CI failures in test/AuxiliaryData.CML.test.ts