### PR TITLE
Refactor: Modularize transaction builder phases into separate files

### DIFF
--- a/docs/content/docs/modules/sdk/Credential.mdx
+++ b/docs/content/docs/modules/sdk/Credential.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Credential.ts
-nav_order: 139
+nav_order: 145
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Datum.mdx
+++ b/docs/content/docs/modules/sdk/Datum.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Datum.ts
-nav_order: 140
+nav_order: 146
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Delegation.mdx
+++ b/docs/content/docs/modules/sdk/Delegation.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Delegation.ts
-nav_order: 141
+nav_order: 147
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Devnet/Devnet.mdx
+++ b/docs/content/docs/modules/sdk/Devnet/Devnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Devnet/Devnet.ts
-nav_order: 142
+nav_order: 148
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Devnet/DevnetDefault.mdx
+++ b/docs/content/docs/modules/sdk/Devnet/DevnetDefault.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Devnet/DevnetDefault.ts
-nav_order: 143
+nav_order: 149
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/EvalRedeemer.mdx
+++ b/docs/content/docs/modules/sdk/EvalRedeemer.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/EvalRedeemer.ts
-nav_order: 144
+nav_order: 150
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Label.mdx
+++ b/docs/content/docs/modules/sdk/Label.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Label.ts
-nav_order: 145
+nav_order: 151
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/OutRef.mdx
+++ b/docs/content/docs/modules/sdk/OutRef.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/OutRef.ts
-nav_order: 146
+nav_order: 152
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/PolicyId.mdx
+++ b/docs/content/docs/modules/sdk/PolicyId.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/PolicyId.ts
-nav_order: 147
+nav_order: 153
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/ProtocolParameters.mdx
+++ b/docs/content/docs/modules/sdk/ProtocolParameters.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/ProtocolParameters.ts
-nav_order: 148
+nav_order: 154
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/RewardAddress.mdx
+++ b/docs/content/docs/modules/sdk/RewardAddress.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/RewardAddress.ts
-nav_order: 154
+nav_order: 160
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Script.mdx
+++ b/docs/content/docs/modules/sdk/Script.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Script.ts
-nav_order: 155
+nav_order: 161
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Type.mdx
+++ b/docs/content/docs/modules/sdk/Type.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Type.ts
-nav_order: 156
+nav_order: 162
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/UTxO.mdx
+++ b/docs/content/docs/modules/sdk/UTxO.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/UTxO.ts
-nav_order: 158
+nav_order: 164
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/Unit.mdx
+++ b/docs/content/docs/modules/sdk/Unit.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/Unit.ts
-nav_order: 157
+nav_order: 163
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/SignBuilder.mdx
+++ b/docs/content/docs/modules/sdk/builders/SignBuilder.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SignBuilder.ts
-nav_order: 129
+nav_order: 135
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/SignBuilderImpl.mdx
+++ b/docs/content/docs/modules/sdk/builders/SignBuilderImpl.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SignBuilderImpl.ts
-nav_order: 130
+nav_order: 136
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/SubmitBuilder.mdx
+++ b/docs/content/docs/modules/sdk/builders/SubmitBuilder.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SubmitBuilder.ts
-nav_order: 131
+nav_order: 137
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/SubmitBuilderImpl.mdx
+++ b/docs/content/docs/modules/sdk/builders/SubmitBuilderImpl.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SubmitBuilderImpl.ts
-nav_order: 132
+nav_order: 138
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/TransactionBuilder.mdx
+++ b/docs/content/docs/modules/sdk/builders/TransactionBuilder.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/TransactionBuilder.ts
-nav_order: 133
+nav_order: 139
 parent: Modules
 ---
 
@@ -32,6 +32,11 @@ double-spending. UTxOs can come from any source (wallet, DeFi protocols, other p
 
 <h2 className="text-delta">Table of contents</h2>
 
+- [builder-interfaces](#builder-interfaces)
+  - [ReadOnlyTransactionBuilder (interface)](#readonlytransactionbuilder-interface)
+  - [SigningTransactionBuilder (interface)](#signingtransactionbuilder-interface)
+  - [TransactionBuilder (type alias)](#transactionbuilder-type-alias)
+  - [TransactionBuilderBase (interface)](#transactionbuilderbase-interface)
 - [config](#config)
   - [ProtocolParameters (interface)](#protocolparameters-interface)
   - [TxBuilderConfig (interface)](#txbuilderconfig-interface)
@@ -39,22 +44,19 @@ double-spending. UTxOs can come from any source (wallet, DeFi protocols, other p
   - [makeTxBuilder](#maketxbuilder)
 - [context](#context)
   - [AvailableUtxosTag (class)](#availableutxostag-class)
+  - [BuildOptionsTag (class)](#buildoptionstag-class)
   - [ChangeAddressTag (class)](#changeaddresstag-class)
   - [ProtocolParametersTag (class)](#protocolparameterstag-class)
   - [TxContext (class)](#txcontext-class)
-  - [TxContextData (interface)](#txcontextdata-interface)
 - [errors](#errors)
   - [EvaluationError (class)](#evaluationerror-class)
   - [TransactionBuilderError (class)](#transactionbuildererror-class)
 - [evaluators](#evaluators)
   - [createUPLCEvaluator](#createuplcevaluator)
-- [interfaces](#interfaces)
-  - [TransactionBuilder (interface)](#transactionbuilder-interface)
 - [model](#model)
+  - [ChainResult (interface)](#chainresult-interface)
   - [EvaluationContext (interface)](#evaluationcontext-interface)
   - [Evaluator (interface)](#evaluator-interface)
-- [options](#options)
-  - [TransactionOptimizations (interface)](#transactionoptimizations-interface)
 - [state](#state)
   - [RedeemerData (interface)](#redeemerdata-interface)
   - [TxBuilderState (interface)](#txbuilderstate-interface)
@@ -63,12 +65,199 @@ double-spending. UTxOs can come from any source (wallet, DeFi protocols, other p
   - [UPLCEvalFunction (type alias)](#uplcevalfunction-type-alias)
 - [utils](#utils)
   - [BuildOptions (interface)](#buildoptions-interface)
-  - [ChainResult (interface)](#chainresult-interface)
+  - [PhaseContextTag (class)](#phasecontexttag-class)
   - [UnfrackAdaOptions (interface)](#unfrackadaoptions-interface)
   - [UnfrackOptions (interface)](#unfrackoptions-interface)
   - [UnfrackTokenOptions (interface)](#unfracktokenoptions-interface)
 
 ---
+
+# builder-interfaces
+
+## ReadOnlyTransactionBuilder (interface)
+
+Transaction builder for read-only wallets (ReadOnlyWallet or undefined).
+
+Builds transactions that cannot be signed. The build() method returns a TransactionResultBase
+which provides query methods like toTransaction() but NOT signing capabilities.
+
+This builder type is returned when makeTxBuilder() is called with a read-only wallet or no wallet.
+Type narrowing happens automatically at construction time - no call-site guards needed.
+
+**Signature**
+
+```ts
+export interface ReadOnlyTransactionBuilder extends TransactionBuilderBase {
+  /**
+   * Execute all queued operations and return a transaction result via Promise.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Can be called multiple times on the same builder instance with independent results.
+   *
+   * @returns Promise<TransactionResultBase> which provides query-only methods
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly build: (options?: BuildOptions) => Promise<TransactionResultBase>
+
+  /**
+   * Execute all queued operations and return a transaction result via Effect.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Suitable for Effect-TS compositional workflows and error handling.
+   *
+   * @returns Effect<TransactionResultBase, ...> which provides query-only methods
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly buildEffect: (
+    options?: BuildOptions
+  ) => Effect.Effect<
+    TransactionResultBase,
+    TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError,
+    never
+  >
+
+  /**
+   * Execute all queued operations with explicit error handling via Either.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Returns Either<Result, Error> for pattern-matched error recovery.
+   *
+   * @returns Promise<Either<TransactionResultBase, Error>>
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly buildEither: (
+    options?: BuildOptions
+  ) => Promise<
+    Either<
+      TransactionResultBase,
+      TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError
+    >
+  >
+}
+```
+
+Added in v2.0.0
+
+## SigningTransactionBuilder (interface)
+
+Transaction builder for signing wallets (SigningWallet or ApiWallet).
+
+Builds transactions that can be signed. The build() method returns a SignBuilder
+which provides sign(), signWithWitness(), and other signing capabilities.
+
+This builder type is returned when makeTxBuilder() is called with a signing wallet.
+Type narrowing happens automatically at construction time - no call-site guards needed.
+
+**Signature**
+
+```ts
+export interface SigningTransactionBuilder extends TransactionBuilderBase {
+  /**
+   * Execute all queued operations and return a signing-ready transaction via Promise.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Can be called multiple times on the same builder instance with independent results.
+   *
+   * @returns Promise<SignBuilder> which provides signing capabilities
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly build: (options?: BuildOptions) => Promise<SignBuilder>
+
+  /**
+   * Execute all queued operations and return a signing-ready transaction via Effect.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Suitable for Effect-TS compositional workflows and error handling.
+   *
+   * @returns Effect<SignBuilder, ...> which provides signing capabilities
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly buildEffect: (
+    options?: BuildOptions
+  ) => Effect.Effect<
+    SignBuilder,
+    TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError,
+    never
+  >
+
+  /**
+   * Execute all queued operations with explicit error handling via Either.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Returns Either<Result, Error> for pattern-matched error recovery.
+   *
+   * @returns Promise<Either<SignBuilder, Error>>
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly buildEither: (
+    options?: BuildOptions
+  ) => Promise<
+    Either<SignBuilder, TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError>
+  >
+}
+```
+
+Added in v2.0.0
+
+## TransactionBuilder (type alias)
+
+Union type for all transaction builders.
+Use specific types (SigningTransactionBuilder or ReadOnlyTransactionBuilder) when you know the wallet type.
+
+**Signature**
+
+```ts
+export type TransactionBuilder = SigningTransactionBuilder | ReadOnlyTransactionBuilder
+```
+
+Added in v2.0.0
+
+## TransactionBuilderBase (interface)
+
+Base interface for both signing and read-only transaction builders.
+Provides chainable builder methods common to both.
+
+**Signature**
+
+```ts
+export interface TransactionBuilderBase {
+  /**
+   * Append a payment output to the transaction.
+   *
+   * Queues a deferred operation that will be executed when build() is called.
+   * Returns the same builder for method chaining.
+   *
+   * @since 2.0.0
+   * @category builder-methods
+   */
+  readonly payToAddress: (params: PayToAddressParams) => this
+
+  /**
+   * Specify transaction inputs from provided UTxOs.
+   *
+   * Queues a deferred operation that will be executed when build() is called.
+   * Returns the same builder for method chaining.
+   *
+   * @since 2.0.0
+   * @category builder-methods
+   */
+  readonly collectFrom: (params: CollectFromParams) => this
+}
+```
+
+Added in v2.0.0
 
 # config
 
@@ -169,15 +358,23 @@ The builder accumulates chainable method calls as deferred ProgramSteps. Calling
 creates fresh state (new Refs) and executes all accumulated programs sequentially, ensuring
 no state pollution between invocations.
 
-Generic type parameter TResult determines what build() returns:
+The return type is determined by the actual wallet provided using conditional types:
 
-- SignBuilder (default): When wallet has signing capability
-- TransactionResultBase: When wallet is read-only
+- SigningTransactionBuilder: When wallet is SigningWallet or ApiWallet
+- ReadOnlyTransactionBuilder: When wallet is ReadOnlyWallet or undefined
+
+Wallet type narrowing happens at construction time based on the wallet's actual type.
+No call-site type narrowing or type guards needed.
+
+Wallet parameter is optional; if omitted, changeAddress and availableUtxos must be
+provided at build time via BuildOptions.
 
 **Signature**
 
 ```ts
-export declare const makeTxBuilder: <TResult = SignBuilder>(config: TxBuilderConfig) => TransactionBuilder<TResult>
+export declare function makeTxBuilder<
+  W extends WalletNew.SigningWallet | WalletNew.ApiWallet | WalletNew.ReadOnlyWallet | undefined
+>(config: Partial<TxBuilderConfig> & { wallet?: W }): TxBuilderResultType<W>
 ```
 
 Added in v2.0.0
@@ -198,6 +395,19 @@ Available to all phase functions via Effect Context.
 
 ```ts
 export declare class AvailableUtxosTag
+```
+
+Added in v2.0.0
+
+## BuildOptionsTag (class)
+
+Context tag providing BuildOptions for the current build.
+Contains build-specific configuration like unfrack, drainTo, onInsufficientChange, etc.
+
+**Signature**
+
+```ts
+export declare class BuildOptionsTag
 ```
 
 Added in v2.0.0
@@ -240,8 +450,8 @@ Added in v2.0.0
 
 ## TxContext (class)
 
-Single Context service providing all transaction building data to programs.
-Combines config (immutable), state (mutable), and options (build-specific).
+Context service providing transaction building state to programs.
+Directly holds the mutable state Ref - config is passed as a regular parameter.
 
 **Signature**
 
@@ -251,27 +461,13 @@ export declare class TxContext
 
 Added in v2.0.0
 
-## TxContextData (interface)
-
-Combined transaction context containing all necessary data for building.
-
-**Signature**
-
-```ts
-export interface TxContextData {
-  readonly config: TxBuilderConfig // Immutable: provider, params, available UTxOs
-  readonly state: TxBuilderState // Mutable: selected UTxOs, outputs, scripts
-  readonly options: BuildOptions // Build-specific: coin selection, evaluator, etc.
-}
-```
-
-Added in v2.0.0
-
 # errors
 
 ## EvaluationError (class)
 
 Error type for failures in script evaluation.
+
+**NOTE: NOT YET IMPLEMENTED** - Reserved for future script evaluation error handling.
 
 **Signature**
 
@@ -298,7 +494,9 @@ Added in v2.0.0
 ## createUPLCEvaluator
 
 Creates an evaluator from a standard UPLC evaluation function.
-The TxBuilder provides protocol parameters and cost models when calling evaluate.
+
+**NOTE: NOT YET IMPLEMENTED** - This function currently returns an evaluator
+that produces dummy data. Reserved for future UPLC script evaluation support.
 
 **Signature**
 
@@ -308,219 +506,33 @@ export declare const createUPLCEvaluator: (_evalFunction: UPLCEvalFunction) => E
 
 Added in v2.0.0
 
-# interfaces
+# model
 
-## TransactionBuilder (interface)
+## ChainResult (interface)
 
-TransactionBuilder with hybrid Effect/Promise API following lucid-evolution pattern.
+Result type for transaction chaining operations.
 
-Architecture:
-
-- Immutable builder instance stores array of ProgramSteps
-- Chainable methods create ProgramSteps and return same builder instance
-- Completion methods (build, chain, etc.) execute all stored ProgramSteps with FRESH state
-- Builder can be reused - each build() call is independent with its own state
-
-Key Design Principle:
-Builder instance never mutates. Programs are deferred Effects that execute later.
-Each build() creates fresh TxBuilderState, executes programs, returns result.
-
-Generic Type Parameter:
-TResult determines the return type of build() methods:
-
-- SignBuilder: When wallet has signing capability (SigningClient)
-- TransactionResultBase: When wallet is read-only (ReadOnlyClient)
-
-Usage Pattern:
-
-```typescript
-const builder = makeTxBuilder(provider, params, costModels, utxos)
-  .payToAddress({ address: "addr1...", assets: { lovelace: 5_000_000n } })
-  .collectFrom({ inputs: [utxo1, utxo2] })
-
-// First build - creates fresh state, executes programs
-const signBuilder1 = await builder.build()
-
-// Second build - NEW fresh state, independent execution
-const signBuilder2 = await builder.build()
-```
+**NOTE: NOT YET IMPLEMENTED** - This interface is reserved for future implementation
+of multi-transaction workflows. Current chain methods return stub implementations.
 
 **Signature**
 
 ```ts
-export interface TransactionBuilder<TResult = SignBuilder> {
-  // ============================================================================
-  // Chainable Builder Methods - Create ProgramSteps, return same builder
-  // ============================================================================
-
-  /**
-   * Append a payment output to the transaction.
-   *
-   * Queues a deferred operation that will be executed when build() is called.
-   * Returns the same builder for method chaining.
-   *
-   * @since 2.0.0
-   * @category builder-methods
-   */
-  readonly payToAddress: (params: PayToAddressParams) => TransactionBuilder<TResult>
-
-  /**
-   * Specify transaction inputs from provided UTxOs.
-   *
-   * Queues a deferred operation that will be executed when build() is called.
-   * Returns the same builder for method chaining.
-   *
-   * @since 2.0.0
-   * @category builder-methods
-   */
-  readonly collectFrom: (params: CollectFromParams) => TransactionBuilder<TResult>
-
-  // Future expansion points for other operations:
-  // readonly mintTokens: (params: MintTokensParams) => TransactionBuilder
-  // readonly delegateStake: (poolId: string) => TransactionBuilder
-  // readonly withdrawRewards: (amount?: Coin.Coin) => TransactionBuilder
-  // readonly addMetadata: (label: string | number, metadata: any) => TransactionBuilder
-  // readonly setValidityInterval: (start?: number, end?: number) => TransactionBuilder
-
-  // ============================================================================
-  // Hybrid Completion Methods - Execute Programs with Fresh State
-  // ============================================================================
-
-  /**
-   * Execute all queued operations and return a signing-ready transaction via Promise.
-   *
-   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
-   * Can be called multiple times on the same builder instance with independent results.
-   *
-   * Returns TResult which is:
-   * - SignBuilder for SigningClient (can sign transactions)
-   * - TransactionResultBase for ReadOnlyClient (unsigned transaction only)
-   *
-   * @since 2.0.0
-   * @category completion-methods
-   */
-  readonly build: (options?: BuildOptions) => Promise<TResult>
-
-  /**
-   * Execute all queued operations and return a signing-ready transaction via Effect.
-   *
-   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
-   * Suitable for Effect-TS compositional workflows and error handling.
-   *
-   * Error types include WalletError and ProviderError from config Effects.
-   *
-   * Returns TResult which is:
-   * - SignBuilder for SigningClient (can sign transactions)
-   * - TransactionResultBase for ReadOnlyClient (unsigned transaction only)
-   *
-   * @since 2.0.0
-   * @category completion-methods
-   */
-  readonly buildEffect: (
-    options?: BuildOptions
-  ) => Effect.Effect<
-    TResult,
-    TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError,
-    unknown
-  >
-
-  /**
-   * Execute all queued operations with explicit error handling via Either.
-   *
-   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
-   * Returns Either<TResult, Error> for pattern-matched error recovery.
-   *
-   * Error types include WalletError and ProviderError from config Effects.
-   *
-   * Returns TResult which is:
-   * - SignBuilder for SigningClient (can sign transactions)
-   * - TransactionResultBase for ReadOnlyClient (unsigned transaction only)
-   *
-   * @since 2.0.0
-   * @category completion-methods
-   */
-  readonly buildEither: (
-    options?: BuildOptions
-  ) => Promise<
-    Either<TResult, TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError>
-  >
-
-  // ============================================================================
-  // Transaction Chaining Methods - Multi-transaction workflows
-  // ============================================================================
-
-  /**
-   * Execute queued operations and return result for multi-transaction workflows via Promise.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns ChainResult containing the transaction,
-   * new UTxOs, and updated available UTxOs for subsequent transactions.
-   *
-   * @since 2.0.0
-   * @category chaining-methods
-   */
-  readonly chain: (options?: BuildOptions) => Promise<ChainResult>
-
-  /**
-   * Execute queued operations and return result for multi-transaction workflows via Effect.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns ChainResult for Effect-TS workflows
-   * and composable error handling.
-   *
-   * @since 2.0.0
-   * @category chaining-methods
-   */
-  readonly chainEffect: (
-    options?: BuildOptions
-  ) => Effect.Effect<ChainResult, TransactionBuilderError | EvaluationError>
-
-  /**
-   * Execute queued operations with explicit error handling via Either for multi-transaction workflows.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns Either<ChainResult, Error>
-   * for pattern-matched error recovery in transaction sequences.
-   *
-   * @since 2.0.0
-   * @category chaining-methods
-   */
-  readonly chainEither: (
-    options?: BuildOptions
-  ) => Promise<Either<ChainResult, TransactionBuilderError | EvaluationError>>
-
-  // ============================================================================
-  // Debug Methods - Inspect transaction state during development
-  // ============================================================================
-
-  /**
-   * Execute queued operations without script evaluation or finalization; return partial transaction via Promise.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns intermediate transaction for inspection.
-   * Useful for debugging transaction assembly and coin selection logic.
-   *
-   * @since 2.0.0
-   * @category debug-methods
-   */
-  readonly buildPartial: () => Promise<Transaction.Transaction>
-
-  /**
-   * Execute queued operations without script evaluation or finalization; return partial transaction via Effect.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns intermediate transaction for inspection.
-   * Suitable for Effect-TS workflows requiring transaction debugging.
-   *
-   * @since 2.0.0
-   * @category debug-methods
-   */
-  readonly buildPartialEffect: () => Effect.Effect<Transaction.Transaction, TransactionBuilderError, unknown>
+export interface ChainResult {
+  readonly transaction: Transaction.Transaction
+  readonly newOutputs: ReadonlyArray<UTxO.UTxO> // UTxOs created by this transaction
+  readonly updatedUtxos: ReadonlyArray<UTxO.UTxO> // Available UTxOs for next transaction (original - spent + new)
+  readonly spentUtxos: ReadonlyArray<UTxO.UTxO> // UTxOs consumed by this transaction
 }
 ```
 
 Added in v2.0.0
 
-# model
-
 ## EvaluationContext (interface)
 
 Data required by script evaluators: cost models, execution limits, and slot configuration.
+
+**NOTE: NOT YET IMPLEMENTED** - Reserved for future UPLC script evaluation support.
 
 **Signature**
 
@@ -547,8 +559,8 @@ Added in v2.0.0
 
 Interface for evaluating transaction scripts and computing execution units.
 
-When provided to builder configuration, replaces default provider-based evaluation.
-Enables custom evaluation strategies including local UPLC execution.
+**NOTE: NOT YET IMPLEMENTED** - Reserved for future custom script evaluation support.
+When implemented, this will enable custom evaluation strategies including local UPLC execution.
 
 **Signature**
 
@@ -565,24 +577,6 @@ export interface Evaluator {
     additionalUtxos: ReadonlyArray<UTxO.UTxO> | undefined,
     context: EvaluationContext
   ) => Effect.Effect<ReadonlyArray<EvalRedeemer>, EvaluationError>
-}
-```
-
-Added in v2.0.0
-
-# options
-
-## TransactionOptimizations (interface)
-
-Transaction optimization flags for controlling builder behavior.
-
-**Signature**
-
-```ts
-export interface TransactionOptimizations {
-  readonly mergeOutputs?: boolean
-  readonly consolidateInputs?: boolean
-  readonly minimizeFee?: boolean
 }
 ```
 
@@ -613,23 +607,19 @@ Added in v2.0.0
 
 ## TxBuilderState (interface)
 
-Mutable state created FRESH on each build() call.
-Contains all Refs for transaction building state.
-
-Design: Stores SDK types (UTxO.UTxO), converts to core types during build.
-This enables coin selection (needs full UTxO context) while maintaining
-transaction-native assembly.
+Mutable state for transaction building.
+Contains all state needed during transaction construction.
 
 **Signature**
 
 ```ts
 export interface TxBuilderState {
-  readonly selectedUtxos: Ref.Ref<ReadonlyArray<UTxO.UTxO>> // SDK type: Array for ordering, converted at build
-  readonly outputs: Ref.Ref<ReadonlyArray<UTxO.TxOutput>> // Transaction outputs (no txHash/outputIndex yet)
-  readonly scripts: Ref.Ref<Map<string, any>> // Scripts attached to the transaction
-  readonly totalOutputAssets: Ref.Ref<Assets.Assets> // Asset totals for balancing
-  readonly totalInputAssets: Ref.Ref<Assets.Assets> // Asset totals for balancing
-  readonly redeemers: Ref.Ref<Map<string, RedeemerData>> // Redeemer data for script inputs
+  readonly selectedUtxos: ReadonlyArray<UTxO.UTxO> // SDK type: Array for ordering, converted at build
+  readonly outputs: ReadonlyArray<UTxO.TxOutput> // Transaction outputs (no txHash/outputIndex yet)
+  readonly scripts: Map<string, any> // Scripts attached to the transaction
+  readonly totalOutputAssets: Assets.Assets // Asset totals for balancing
+  readonly totalInputAssets: Assets.Assets // Asset totals for balancing
+  readonly redeemers: Map<string, RedeemerData> // Redeemer data for script inputs
 }
 ```
 
@@ -663,9 +653,7 @@ type ProgramStep = Effect.Effect<void, TransactionBuilderError, TxContext>
 
 Requirements from context:
 
-- TxContext.config: Immutable configuration (provider, protocol params, available UTxOs)
-- TxContext.state: Mutable state (selected UTxOs, outputs, scripts, assets)
-- TxContext.options: Build options (coin selection, evaluator, collateral, etc.)
+- TxContext: Mutable state Ref (selected UTxOs, outputs, scripts, assets)
 
 **Signature**
 
@@ -678,6 +666,8 @@ Added in v2.0.0
 ## UPLCEvalFunction (type alias)
 
 Standard UPLC evaluation function signature (matches UPLC.eval_phase_two_raw).
+
+**NOTE: NOT YET IMPLEMENTED** - Reserved for future UPLC evaluation support.
 
 **Signature**
 
@@ -915,32 +905,15 @@ export interface BuildOptions {
    * @default false
    */
   readonly useStateMachine?: boolean
-
-  /**
-   *
-   * When true, uses simplified 4-phase state machine:
-   * - selection → changeValidation → balanceVerification → fallback → complete
-   *
-   * shares TxContext with V2 but uses mathematical validation approach.
-   *
-   * @experimental
-   * @default false
-   */
-  readonly useV3?: boolean
 }
 ````
 
-## ChainResult (interface)
+## PhaseContextTag (class)
 
 **Signature**
 
 ```ts
-export interface ChainResult {
-  readonly transaction: Transaction.Transaction
-  readonly newOutputs: ReadonlyArray<UTxO.UTxO> // UTxOs created by this transaction
-  readonly updatedUtxos: ReadonlyArray<UTxO.UTxO> // Available UTxOs for next transaction (original - spent + new)
-  readonly spentUtxos: ReadonlyArray<UTxO.UTxO> // UTxOs consumed by this transaction
-}
+export declare class PhaseContextTag
 ```
 
 ## UnfrackAdaOptions (interface)

--- a/docs/content/docs/modules/sdk/builders/TransactionResult.mdx
+++ b/docs/content/docs/modules/sdk/builders/TransactionResult.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/TransactionResult.ts
-nav_order: 134
+nav_order: 140
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/TxBuilderImpl.mdx
+++ b/docs/content/docs/modules/sdk/builders/TxBuilderImpl.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/TxBuilderImpl.ts
-nav_order: 135
+nav_order: 141
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/builders/Unfrack.mdx
+++ b/docs/content/docs/modules/sdk/builders/Unfrack.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/Unfrack.ts
-nav_order: 136
+nav_order: 142
 parent: Modules
 ---
 
@@ -76,7 +76,7 @@ This ensures all outputs are always valid.
 export declare const createUnfrackedChangeOutputs: (
   changeAddress: string,
   changeAssets: Assets.Assets,
-  options: UnfrackOptions,
+  options: UnfrackOptions | undefined,
   coinsPerUtxoByte: bigint
 ) => Effect.Effect<ReadonlyArray<UTxO.TxOutput>, Error, never>
 ```

--- a/docs/content/docs/modules/sdk/builders/phases/Balance.mdx
+++ b/docs/content/docs/modules/sdk/builders/phases/Balance.mdx
@@ -1,0 +1,69 @@
+---
+title: sdk/builders/phases/Balance.ts
+nav_order: 129
+parent: Modules
+---
+
+## Balance overview
+
+Balance Verification Phase
+
+Verifies that transaction inputs exactly equal outputs + change + fees.
+Handles three scenarios: balanced (complete), shortfall (retry), or excess (burn/drain).
+
+Added in v2.0.0
+
+---
+
+<h2 className="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeBalance](#executebalance)
+
+---
+
+# utils
+
+## executeBalance
+
+Balance Verification Phase
+
+Verifies that transaction inputs exactly equal outputs + change + fees.
+Handles three scenarios: balanced (complete), shortfall (retry), or excess (burn/drain).
+
+**Decision Flow:**
+
+```
+Calculate Delta: inputs - outputs - change - fees
+  ↓
+Delta == 0?
+  ├─ YES → BALANCED: Complete transaction
+  └─ NO → Check delta value
+          ↓
+       Delta > 0 (Excess)?
+          ├─ YES → Check strategy
+          │         ├─ DrainTo mode? → Merge into target output → Complete
+          │         ├─ Burn mode? → Accept as implicit fee → Complete
+          │         └─ Neither? → ERROR (bug in change creation)
+          └─ NO (Delta < 0, Shortfall) → Return to changeCreation
+```
+
+**Key Principles:**
+
+- Delta must equal exactly 0 (balanced) or negative (shortfall) in normal flow
+- Positive delta only occurs in burn/drainTo strategies (controlled scenarios)
+- Shortfall means change was underestimated; retry with adjusted fee
+- DrainTo merges excess into a specified output for exact balancing
+- Burn strategy treats excess as implicit fee (leftover becomes network fee)
+- Native assets in delta indicate a bug (should never happen with proper change creation)
+- This is the final verification gate before transaction completion
+
+**Signature**
+
+```ts
+export declare const executeBalance: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | BuildOptionsTag
+>
+```

--- a/docs/content/docs/modules/sdk/builders/phases/ChangeCreation.mdx
+++ b/docs/content/docs/modules/sdk/builders/phases/ChangeCreation.mdx
@@ -1,0 +1,97 @@
+---
+title: sdk/builders/phases/ChangeCreation.ts
+nav_order: 130
+parent: Modules
+---
+
+## ChangeCreation overview
+
+Change Creation Phase - Change Output Generation
+
+Creates change outputs from leftover assets using a cascading retry strategy.
+Handles both unfrack (N outputs) and single output approaches with fallback options.
+
+Added in v2.0.0
+
+---
+
+<h2 className="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeChangeCreation](#executechangecreation)
+
+---
+
+# utils
+
+## executeChangeCreation
+
+Change Creation Phase
+
+Creates change outputs from leftover assets using a cascading retry strategy.
+Both unfrack (N outputs) and single output follow the same retry pattern:
+try with available funds → if insufficient, reselect (up to MAX_ATTEMPTS) → fallback.
+
+**Symmetric Retry Flow (Unfrack vs Single Output):**
+
+```
+UNFRACK (N outputs)                    SINGLE OUTPUT (1 output)
+─────────────────────────────────────────────────────────────────
+
+Try: Create N outputs                  Try: Create 1 output
+↓                                      ↓
+Check: leftover >= (minUTxO × N)?      Check: leftover >= minUTxO?
+↓                                      ↓
+If NO (not affordable):                If NO (insufficient):
+  ├─ attempt < MAX? → Reselect           ├─ attempt < MAX? → Reselect
+  └─ attempt >= MAX? → Fallback          └─ attempt >= MAX? → Fallback
+                                                              ↓
+Fallback:                              Fallback:
+  └─ Single output                       ├─ drainTo (merge into output)
+      ├─ (retry/fallback)                ├─ burn (leftover → fee)
+      └─ ...                             └─ error
+```
+
+**Detailed Flow:**
+
+```
+1. Calculate tentative leftover (inputs - outputs - contextFee)
+
+2. If unfrack enabled and canUnfrack=true:
+   → Try createUnfrackedChangeOutputs() (N outputs)
+   → Success: store N outputs, goto FeeCalculation
+   → Not affordable:
+      ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
+      └─ If attempt >= MAX_ATTEMPTS: canUnfrack=false, goto step 3
+
+3. Single output approach:
+   → Create 1 change output with leftover
+   → Success: store 1 output, goto FeeCalculation
+   → Not affordable:
+      ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
+      └─ If attempt >= MAX_ATTEMPTS: goto step 4
+
+4. Insufficient change fallbacks (single-output only):
+   a. If drainTo specified: merge into existing output
+   b. If onInsufficientChange="burn": leftover becomes fee
+   c. If onInsufficientChange="error": throw error
+```
+
+**Key Principles:**
+
+- Unfrack and single output use SAME retry mechanism (reselection up to MAX_ATTEMPTS)
+- Phase loop handles fee convergence (leftover recalculated each iteration)
+- Last subdivision output absorbs remainder for exact balance
+- canUnfrack flag prevents retry loops (once false, stays false)
+- drainTo and burn are terminal fallbacks (single-output only)
+- Unfrack outputs bypass drainTo/burn (they're already valid)
+
+**Signature**
+
+```ts
+export declare const executeChangeCreation: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | ChangeAddressTag | BuildOptionsTag | ProtocolParametersTag | AvailableUtxosTag
+>
+```

--- a/docs/content/docs/modules/sdk/builders/phases/Fallback.mdx
+++ b/docs/content/docs/modules/sdk/builders/phases/Fallback.mdx
@@ -1,0 +1,74 @@
+---
+title: sdk/builders/phases/Fallback.ts
+nav_order: 131
+parent: Modules
+---
+
+## Fallback overview
+
+Fallback Phase - Terminal Strategy Selection
+
+Handles insufficient change scenarios after MAX_ATTEMPTS exhausted in ChangeCreation.
+Routes to one of two terminal strategies: drainTo (merge leftover) or burn (implicit fee).
+
+Added in v2.0.0
+
+---
+
+<h2 className="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeFallback](#executefallback)
+
+---
+
+# utils
+
+## executeFallback
+
+Fallback Phase - Terminal Strategy Selection
+
+Handles insufficient change scenarios after MAX_ATTEMPTS exhausted in ChangeCreation.
+Routes to one of two terminal strategies: drainTo (merge leftover) or burn (implicit fee).
+This phase is only reached when change creation cannot create a valid change output
+and a fallback strategy is configured.
+
+**Decision Flow:**
+
+```
+Fallback Phase Triggered
+(MAX_ATTEMPTS exhausted in changeCreation)
+  ↓
+Check: drainTo configured?
+  ├─ YES → Validate drainTo index
+  │         ├─ Valid → Clear change outputs
+  │         │          Return to feeCalculation
+  │         │          (leftover merged in balance phase)
+  │         └─ Invalid → ERROR (invalid output index)
+  └─ NO → Check: burn strategy?
+          ├─ YES → Clear change outputs
+          │        Return to feeCalculation
+          │        (leftover becomes implicit fee)
+          └─ NO → ERROR (no strategy configured)
+                  (ChangeCreation should prevent this)
+```
+
+**Key Principles:**
+
+- Fallback only handles ADA-only leftover (ChangeCreation filters native asset cases)
+- DrainTo merges excess into a specified output, deferring actual merge to Balance phase
+- Burn strategy accepts leftover as implicit network fee
+- Both strategies clear change outputs and recalculate fee (leftover not in outputs)
+- Invalid drainTo index is caught here with validation
+- Reaching fallback without a strategy configured indicates a bug in ChangeCreation routing
+- Fee recalculation after clearing change ensures accurate final fee
+
+**Signature**
+
+```ts
+export declare const executeFallback: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | BuildOptionsTag
+>
+```

--- a/docs/content/docs/modules/sdk/builders/phases/FeeCalculation.mdx
+++ b/docs/content/docs/modules/sdk/builders/phases/FeeCalculation.mdx
@@ -1,0 +1,73 @@
+---
+title: sdk/builders/phases/FeeCalculation.ts
+nav_order: 132
+parent: Modules
+---
+
+## FeeCalculation overview
+
+Fee Calculation Phase
+
+Calculates transaction fee based on current inputs and outputs (including change).
+Stores both calculated fee and leftover amount for the Balance phase to verify.
+
+Added in v2.0.0
+
+---
+
+<h2 className="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeFeeCalculation](#executefeecalculation)
+
+---
+
+# utils
+
+## executeFeeCalculation
+
+Fee Calculation Phase
+
+Calculates transaction fee based on current inputs and outputs (including change).
+Stores both calculated fee and leftover amount for the Balance phase to verify.
+This phase is deterministic once inputs and outputs are fixed.
+
+**Decision Flow:**
+
+```
+Combine Inputs & Outputs
+(base outputs + change outputs)
+  ↓
+Calculate Fee Iteratively
+(account for changing tx size during fee calculation)
+  ↓
+Calculate Leftover After Fee
+(inputs - outputs - change - fee)
+  ↓
+Store Fee & Leftover
+(in build context for Balance phase)
+  ↓
+goto balance
+```
+
+**Key Principles:**
+
+- Fee calculation is deterministic given fixed inputs/outputs/change
+- Iterative calculation accounts for fee size affecting tx size
+- Leftover = inputs - outputs - change - fee (can be 0, positive, or negative)
+- Positive leftover triggers Balance → drainTo/burn strategies
+- Negative leftover (shortfall) triggers Balance → reselection
+- Zero leftover means perfectly balanced (ideal case)
+- Change outputs are always included in fee calculation
+- Fee is stored in context for Balance phase validation
+- No phase retries here; Balance phase decides next step based on leftover
+
+**Signature**
+
+```ts
+export declare const executeFeeCalculation: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | ProtocolParametersTag
+>
+```

--- a/docs/content/docs/modules/sdk/builders/phases/Phases.mdx
+++ b/docs/content/docs/modules/sdk/builders/phases/Phases.mdx
@@ -1,0 +1,52 @@
+---
+title: sdk/builders/phases/Phases.ts
+nav_order: 133
+parent: Modules
+---
+
+## Phases overview
+
+Core type definitions for transaction builder phases.
+
+Each phase is modularized into its own file and executes as part
+of the transaction state machine.
+
+Added in v2.0.0
+
+---
+
+<h2 className="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [Phase (type alias)](#phase-type-alias)
+  - [PhaseResult (interface)](#phaseresult-interface)
+
+---
+
+# utils
+
+## Phase (type alias)
+
+Build phases of the transaction state machine.
+
+**Signature**
+
+```ts
+export type Phase = "selection" | "changeCreation" | "feeCalculation" | "balance" | "fallback" | "complete"
+```
+
+Added in v2.0.0
+
+## PhaseResult (interface)
+
+Result returned by a phase indicating the next phase to execute.
+
+**Signature**
+
+```ts
+export interface PhaseResult {
+  readonly next: Phase
+}
+```
+
+Added in v2.0.0

--- a/docs/content/docs/modules/sdk/builders/phases/Selection.mdx
+++ b/docs/content/docs/modules/sdk/builders/phases/Selection.mdx
@@ -1,0 +1,77 @@
+---
+title: sdk/builders/phases/Selection.ts
+nav_order: 134
+parent: Modules
+---
+
+## Selection overview
+
+Selection Phase - UTxO Coin Selection
+
+Selects UTxOs from available pool to cover transaction outputs, fees, and change requirements.
+Handles both initial selection and reselection with retry logic up to MAX_ATTEMPTS.
+
+Added in v2.0.0
+
+---
+
+<h2 className="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeSelection](#executeselection)
+
+---
+
+# utils
+
+## executeSelection
+
+Selection Phase - UTxO Coin Selection
+
+Selects UTxOs from available pool to cover transaction outputs, fees, and change requirements.
+Handles both initial selection and reselection with retry logic up to MAX_ATTEMPTS.
+
+**Decision Flow:**
+
+```
+Calculate Required Assets
+(outputs + shortfall for fees/change)
+  ↓
+Assets Sufficient?
+(inputs >= required)
+  ├─ YES → No selection needed
+  │        (use existing explicit inputs only)
+  │        goto changeCreation
+  └─ NO → Calculate asset delta
+          ├─ Shortfall from fees? → Reselection mode
+          │  (select more lovelace for change minUTxO)
+          └─ Shortfall from outputs? → Normal selection
+             (select missing native assets or lovelace)
+          ↓
+       Perform coin selection
+       (update totalInputAssets)
+       ↓
+       Increment attempt counter
+       goto changeCreation
+```
+
+**Key Principles:**
+
+- Selection phase runs once per state machine iteration
+- Reselection (shortfall > 0) adds more UTxOs within MAX_ATTEMPTS limit
+- Selection itself doesn't fail; ChangeCreation may trigger reselection
+- No selection needed if explicit inputs already cover requirements
+- Shortfall tracks lovelace deficit for change output minUTxO
+- Asset delta identifies what additional UTxOs must contain
+- Attempt counter resets at phase start, incremented at phase end
+- Selection is deterministic (same inputs = same selection)
+
+**Signature**
+
+```ts
+export declare const executeSelection: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | AvailableUtxosTag | BuildOptionsTag
+>
+```

--- a/docs/content/docs/modules/sdk/client/Client.mdx
+++ b/docs/content/docs/modules/sdk/client/Client.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/client/Client.ts
-nav_order: 137
+nav_order: 143
 parent: Modules
 ---
 
@@ -261,9 +261,6 @@ export type ReadOnlyClient = EffectToPromiseAPI<ReadOnlyClientEffect> & {
    * - `.toTransactionWithFakeWitnesses()` - Get transaction with fake witnesses for fee validation
    * - `.estimateFee()` - Get the calculated fee
    *
-   * @param utxos - Optional UTxOs to use for coin selection. If not provided, wallet UTxOs will be fetched automatically when build() is called.
-   * @returns A new TransactionBuilder instance configured with cached protocol parameters and wallet change address.
-   *
    * @example
    * ```typescript
    * // Build unsigned transaction
@@ -282,7 +279,7 @@ export type ReadOnlyClient = EffectToPromiseAPI<ReadOnlyClientEffect> & {
    * @since 2.0.0
    * @category transaction-building
    */
-  readonly newTx: (utxos?: ReadonlyArray<UTxO.UTxO>) => TransactionBuilder<TransactionResultBase>
+  readonly newTx: (utxos?: ReadonlyArray<UTxO.UTxO>) => ReadOnlyTransactionBuilder
   // Effect namespace - includes all provider + wallet methods as Effects
   readonly Effect: ReadOnlyClientEffect
 }
@@ -453,7 +450,7 @@ export type SigningClient = EffectToPromiseAPI<SigningClientEffect> & {
    * @since 2.0.0
    * @category transaction-building
    */
-  readonly newTx: () => TransactionBuilder
+  readonly newTx: () => SigningTransactionBuilder
   // Effect namespace - includes all provider + wallet methods as Effects
   readonly Effect: SigningClientEffect
 }

--- a/docs/content/docs/modules/sdk/client/ClientImpl.mdx
+++ b/docs/content/docs/modules/sdk/client/ClientImpl.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/client/ClientImpl.ts
-nav_order: 138
+nav_order: 144
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/provider/Blockfrost.mdx
+++ b/docs/content/docs/modules/sdk/provider/Blockfrost.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Blockfrost.ts
-nav_order: 149
+nav_order: 155
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/provider/Koios.mdx
+++ b/docs/content/docs/modules/sdk/provider/Koios.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Koios.ts
-nav_order: 150
+nav_order: 156
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/provider/Kupmios.mdx
+++ b/docs/content/docs/modules/sdk/provider/Kupmios.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Kupmios.ts
-nav_order: 151
+nav_order: 157
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/provider/Maestro.mdx
+++ b/docs/content/docs/modules/sdk/provider/Maestro.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Maestro.ts
-nav_order: 152
+nav_order: 158
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/provider/Provider.mdx
+++ b/docs/content/docs/modules/sdk/provider/Provider.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Provider.ts
-nav_order: 153
+nav_order: 159
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/wallet/Derivation.mdx
+++ b/docs/content/docs/modules/sdk/wallet/Derivation.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/wallet/Derivation.ts
-nav_order: 159
+nav_order: 165
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/wallet/Wallet.mdx
+++ b/docs/content/docs/modules/sdk/wallet/Wallet.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/wallet/Wallet.ts
-nav_order: 160
+nav_order: 166
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/sdk/wallet/WalletNew.mdx
+++ b/docs/content/docs/modules/sdk/wallet/WalletNew.mdx
@@ -1,6 +1,6 @@
 ---
 title: sdk/wallet/WalletNew.ts
-nav_order: 161
+nav_order: 167
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/utils/FeeValidation.mdx
+++ b/docs/content/docs/modules/utils/FeeValidation.mdx
@@ -1,6 +1,6 @@
 ---
 title: utils/FeeValidation.ts
-nav_order: 163
+nav_order: 169
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/utils/Hash.mdx
+++ b/docs/content/docs/modules/utils/Hash.mdx
@@ -1,6 +1,6 @@
 ---
 title: utils/Hash.ts
-nav_order: 164
+nav_order: 170
 parent: Modules
 ---
 

--- a/docs/content/docs/modules/utils/effect-runtime.mdx
+++ b/docs/content/docs/modules/utils/effect-runtime.mdx
@@ -1,6 +1,6 @@
 ---
 title: utils/effect-runtime.ts
-nav_order: 162
+nav_order: 168
 parent: Modules
 ---
 

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./out/types/routes.d.ts" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/evolution/docs/modules/sdk/Credential.ts.md
+++ b/packages/evolution/docs/modules/sdk/Credential.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Credential.ts
-nav_order: 139
+nav_order: 145
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Datum.ts.md
+++ b/packages/evolution/docs/modules/sdk/Datum.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Datum.ts
-nav_order: 140
+nav_order: 146
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Delegation.ts.md
+++ b/packages/evolution/docs/modules/sdk/Delegation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Delegation.ts
-nav_order: 141
+nav_order: 147
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Devnet/Devnet.ts.md
+++ b/packages/evolution/docs/modules/sdk/Devnet/Devnet.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Devnet/Devnet.ts
-nav_order: 142
+nav_order: 148
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Devnet/DevnetDefault.ts.md
+++ b/packages/evolution/docs/modules/sdk/Devnet/DevnetDefault.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Devnet/DevnetDefault.ts
-nav_order: 143
+nav_order: 149
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/EvalRedeemer.ts.md
+++ b/packages/evolution/docs/modules/sdk/EvalRedeemer.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/EvalRedeemer.ts
-nav_order: 144
+nav_order: 150
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Label.ts.md
+++ b/packages/evolution/docs/modules/sdk/Label.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Label.ts
-nav_order: 145
+nav_order: 151
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/OutRef.ts.md
+++ b/packages/evolution/docs/modules/sdk/OutRef.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/OutRef.ts
-nav_order: 146
+nav_order: 152
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/PolicyId.ts.md
+++ b/packages/evolution/docs/modules/sdk/PolicyId.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/PolicyId.ts
-nav_order: 147
+nav_order: 153
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/ProtocolParameters.ts.md
+++ b/packages/evolution/docs/modules/sdk/ProtocolParameters.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/ProtocolParameters.ts
-nav_order: 148
+nav_order: 154
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/RewardAddress.ts.md
+++ b/packages/evolution/docs/modules/sdk/RewardAddress.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/RewardAddress.ts
-nav_order: 154
+nav_order: 160
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Script.ts.md
+++ b/packages/evolution/docs/modules/sdk/Script.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Script.ts
-nav_order: 155
+nav_order: 161
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Type.ts.md
+++ b/packages/evolution/docs/modules/sdk/Type.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Type.ts
-nav_order: 156
+nav_order: 162
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/UTxO.ts.md
+++ b/packages/evolution/docs/modules/sdk/UTxO.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/UTxO.ts
-nav_order: 158
+nav_order: 164
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/Unit.ts.md
+++ b/packages/evolution/docs/modules/sdk/Unit.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/Unit.ts
-nav_order: 157
+nav_order: 163
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/SignBuilder.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/SignBuilder.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SignBuilder.ts
-nav_order: 129
+nav_order: 135
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/SignBuilderImpl.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/SignBuilderImpl.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SignBuilderImpl.ts
-nav_order: 130
+nav_order: 136
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/SubmitBuilder.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/SubmitBuilder.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SubmitBuilder.ts
-nav_order: 131
+nav_order: 137
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/SubmitBuilderImpl.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/SubmitBuilderImpl.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/SubmitBuilderImpl.ts
-nav_order: 132
+nav_order: 138
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/TransactionResult.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/TransactionResult.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/TransactionResult.ts
-nav_order: 134
+nav_order: 140
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/TxBuilderImpl.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/TxBuilderImpl.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/TxBuilderImpl.ts
-nav_order: 135
+nav_order: 141
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/builders/Unfrack.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/Unfrack.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/builders/Unfrack.ts
-nav_order: 136
+nav_order: 142
 parent: Modules
 ---
 
@@ -76,7 +76,7 @@ This ensures all outputs are always valid.
 export declare const createUnfrackedChangeOutputs: (
   changeAddress: string,
   changeAssets: Assets.Assets,
-  options: UnfrackOptions,
+  options: UnfrackOptions | undefined,
   coinsPerUtxoByte: bigint
 ) => Effect.Effect<ReadonlyArray<UTxO.TxOutput>, Error, never>
 ```

--- a/packages/evolution/docs/modules/sdk/builders/phases/Balance.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/phases/Balance.ts.md
@@ -1,0 +1,69 @@
+---
+title: sdk/builders/phases/Balance.ts
+nav_order: 129
+parent: Modules
+---
+
+## Balance overview
+
+Balance Verification Phase
+
+Verifies that transaction inputs exactly equal outputs + change + fees.
+Handles three scenarios: balanced (complete), shortfall (retry), or excess (burn/drain).
+
+Added in v2.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeBalance](#executebalance)
+
+---
+
+# utils
+
+## executeBalance
+
+Balance Verification Phase
+
+Verifies that transaction inputs exactly equal outputs + change + fees.
+Handles three scenarios: balanced (complete), shortfall (retry), or excess (burn/drain).
+
+**Decision Flow:**
+
+```
+Calculate Delta: inputs - outputs - change - fees
+  ↓
+Delta == 0?
+  ├─ YES → BALANCED: Complete transaction
+  └─ NO → Check delta value
+          ↓
+       Delta > 0 (Excess)?
+          ├─ YES → Check strategy
+          │         ├─ DrainTo mode? → Merge into target output → Complete
+          │         ├─ Burn mode? → Accept as implicit fee → Complete
+          │         └─ Neither? → ERROR (bug in change creation)
+          └─ NO (Delta < 0, Shortfall) → Return to changeCreation
+```
+
+**Key Principles:**
+
+- Delta must equal exactly 0 (balanced) or negative (shortfall) in normal flow
+- Positive delta only occurs in burn/drainTo strategies (controlled scenarios)
+- Shortfall means change was underestimated; retry with adjusted fee
+- DrainTo merges excess into a specified output for exact balancing
+- Burn strategy treats excess as implicit fee (leftover becomes network fee)
+- Native assets in delta indicate a bug (should never happen with proper change creation)
+- This is the final verification gate before transaction completion
+
+**Signature**
+
+```ts
+export declare const executeBalance: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | BuildOptionsTag
+>
+```

--- a/packages/evolution/docs/modules/sdk/builders/phases/ChangeCreation.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/phases/ChangeCreation.ts.md
@@ -1,0 +1,97 @@
+---
+title: sdk/builders/phases/ChangeCreation.ts
+nav_order: 130
+parent: Modules
+---
+
+## ChangeCreation overview
+
+Change Creation Phase - Change Output Generation
+
+Creates change outputs from leftover assets using a cascading retry strategy.
+Handles both unfrack (N outputs) and single output approaches with fallback options.
+
+Added in v2.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeChangeCreation](#executechangecreation)
+
+---
+
+# utils
+
+## executeChangeCreation
+
+Change Creation Phase
+
+Creates change outputs from leftover assets using a cascading retry strategy.
+Both unfrack (N outputs) and single output follow the same retry pattern:
+try with available funds → if insufficient, reselect (up to MAX_ATTEMPTS) → fallback.
+
+**Symmetric Retry Flow (Unfrack vs Single Output):**
+
+```
+UNFRACK (N outputs)                    SINGLE OUTPUT (1 output)
+─────────────────────────────────────────────────────────────────
+
+Try: Create N outputs                  Try: Create 1 output
+↓                                      ↓
+Check: leftover >= (minUTxO × N)?      Check: leftover >= minUTxO?
+↓                                      ↓
+If NO (not affordable):                If NO (insufficient):
+  ├─ attempt < MAX? → Reselect           ├─ attempt < MAX? → Reselect
+  └─ attempt >= MAX? → Fallback          └─ attempt >= MAX? → Fallback
+                                                              ↓
+Fallback:                              Fallback:
+  └─ Single output                       ├─ drainTo (merge into output)
+      ├─ (retry/fallback)                ├─ burn (leftover → fee)
+      └─ ...                             └─ error
+```
+
+**Detailed Flow:**
+
+```
+1. Calculate tentative leftover (inputs - outputs - contextFee)
+
+2. If unfrack enabled and canUnfrack=true:
+   → Try createUnfrackedChangeOutputs() (N outputs)
+   → Success: store N outputs, goto FeeCalculation
+   → Not affordable:
+      ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
+      └─ If attempt >= MAX_ATTEMPTS: canUnfrack=false, goto step 3
+
+3. Single output approach:
+   → Create 1 change output with leftover
+   → Success: store 1 output, goto FeeCalculation
+   → Not affordable:
+      ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
+      └─ If attempt >= MAX_ATTEMPTS: goto step 4
+
+4. Insufficient change fallbacks (single-output only):
+   a. If drainTo specified: merge into existing output
+   b. If onInsufficientChange="burn": leftover becomes fee
+   c. If onInsufficientChange="error": throw error
+```
+
+**Key Principles:**
+
+- Unfrack and single output use SAME retry mechanism (reselection up to MAX_ATTEMPTS)
+- Phase loop handles fee convergence (leftover recalculated each iteration)
+- Last subdivision output absorbs remainder for exact balance
+- canUnfrack flag prevents retry loops (once false, stays false)
+- drainTo and burn are terminal fallbacks (single-output only)
+- Unfrack outputs bypass drainTo/burn (they're already valid)
+
+**Signature**
+
+```ts
+export declare const executeChangeCreation: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | ChangeAddressTag | BuildOptionsTag | ProtocolParametersTag | AvailableUtxosTag
+>
+```

--- a/packages/evolution/docs/modules/sdk/builders/phases/Fallback.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/phases/Fallback.ts.md
@@ -1,0 +1,74 @@
+---
+title: sdk/builders/phases/Fallback.ts
+nav_order: 131
+parent: Modules
+---
+
+## Fallback overview
+
+Fallback Phase - Terminal Strategy Selection
+
+Handles insufficient change scenarios after MAX_ATTEMPTS exhausted in ChangeCreation.
+Routes to one of two terminal strategies: drainTo (merge leftover) or burn (implicit fee).
+
+Added in v2.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeFallback](#executefallback)
+
+---
+
+# utils
+
+## executeFallback
+
+Fallback Phase - Terminal Strategy Selection
+
+Handles insufficient change scenarios after MAX_ATTEMPTS exhausted in ChangeCreation.
+Routes to one of two terminal strategies: drainTo (merge leftover) or burn (implicit fee).
+This phase is only reached when change creation cannot create a valid change output
+and a fallback strategy is configured.
+
+**Decision Flow:**
+
+```
+Fallback Phase Triggered
+(MAX_ATTEMPTS exhausted in changeCreation)
+  ↓
+Check: drainTo configured?
+  ├─ YES → Validate drainTo index
+  │         ├─ Valid → Clear change outputs
+  │         │          Return to feeCalculation
+  │         │          (leftover merged in balance phase)
+  │         └─ Invalid → ERROR (invalid output index)
+  └─ NO → Check: burn strategy?
+          ├─ YES → Clear change outputs
+          │        Return to feeCalculation
+          │        (leftover becomes implicit fee)
+          └─ NO → ERROR (no strategy configured)
+                  (ChangeCreation should prevent this)
+```
+
+**Key Principles:**
+
+- Fallback only handles ADA-only leftover (ChangeCreation filters native asset cases)
+- DrainTo merges excess into a specified output, deferring actual merge to Balance phase
+- Burn strategy accepts leftover as implicit network fee
+- Both strategies clear change outputs and recalculate fee (leftover not in outputs)
+- Invalid drainTo index is caught here with validation
+- Reaching fallback without a strategy configured indicates a bug in ChangeCreation routing
+- Fee recalculation after clearing change ensures accurate final fee
+
+**Signature**
+
+```ts
+export declare const executeFallback: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | BuildOptionsTag
+>
+```

--- a/packages/evolution/docs/modules/sdk/builders/phases/FeeCalculation.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/phases/FeeCalculation.ts.md
@@ -1,0 +1,73 @@
+---
+title: sdk/builders/phases/FeeCalculation.ts
+nav_order: 132
+parent: Modules
+---
+
+## FeeCalculation overview
+
+Fee Calculation Phase
+
+Calculates transaction fee based on current inputs and outputs (including change).
+Stores both calculated fee and leftover amount for the Balance phase to verify.
+
+Added in v2.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeFeeCalculation](#executefeecalculation)
+
+---
+
+# utils
+
+## executeFeeCalculation
+
+Fee Calculation Phase
+
+Calculates transaction fee based on current inputs and outputs (including change).
+Stores both calculated fee and leftover amount for the Balance phase to verify.
+This phase is deterministic once inputs and outputs are fixed.
+
+**Decision Flow:**
+
+```
+Combine Inputs & Outputs
+(base outputs + change outputs)
+  ↓
+Calculate Fee Iteratively
+(account for changing tx size during fee calculation)
+  ↓
+Calculate Leftover After Fee
+(inputs - outputs - change - fee)
+  ↓
+Store Fee & Leftover
+(in build context for Balance phase)
+  ↓
+goto balance
+```
+
+**Key Principles:**
+
+- Fee calculation is deterministic given fixed inputs/outputs/change
+- Iterative calculation accounts for fee size affecting tx size
+- Leftover = inputs - outputs - change - fee (can be 0, positive, or negative)
+- Positive leftover triggers Balance → drainTo/burn strategies
+- Negative leftover (shortfall) triggers Balance → reselection
+- Zero leftover means perfectly balanced (ideal case)
+- Change outputs are always included in fee calculation
+- Fee is stored in context for Balance phase validation
+- No phase retries here; Balance phase decides next step based on leftover
+
+**Signature**
+
+```ts
+export declare const executeFeeCalculation: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | ProtocolParametersTag
+>
+```

--- a/packages/evolution/docs/modules/sdk/builders/phases/Phases.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/phases/Phases.ts.md
@@ -1,0 +1,52 @@
+---
+title: sdk/builders/phases/Phases.ts
+nav_order: 133
+parent: Modules
+---
+
+## Phases overview
+
+Core type definitions for transaction builder phases.
+
+Each phase is modularized into its own file and executes as part
+of the transaction state machine.
+
+Added in v2.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [Phase (type alias)](#phase-type-alias)
+  - [PhaseResult (interface)](#phaseresult-interface)
+
+---
+
+# utils
+
+## Phase (type alias)
+
+Build phases of the transaction state machine.
+
+**Signature**
+
+```ts
+export type Phase = "selection" | "changeCreation" | "feeCalculation" | "balance" | "fallback" | "complete"
+```
+
+Added in v2.0.0
+
+## PhaseResult (interface)
+
+Result returned by a phase indicating the next phase to execute.
+
+**Signature**
+
+```ts
+export interface PhaseResult {
+  readonly next: Phase
+}
+```
+
+Added in v2.0.0

--- a/packages/evolution/docs/modules/sdk/builders/phases/Selection.ts.md
+++ b/packages/evolution/docs/modules/sdk/builders/phases/Selection.ts.md
@@ -1,0 +1,77 @@
+---
+title: sdk/builders/phases/Selection.ts
+nav_order: 134
+parent: Modules
+---
+
+## Selection overview
+
+Selection Phase - UTxO Coin Selection
+
+Selects UTxOs from available pool to cover transaction outputs, fees, and change requirements.
+Handles both initial selection and reselection with retry logic up to MAX_ATTEMPTS.
+
+Added in v2.0.0
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [utils](#utils)
+  - [executeSelection](#executeselection)
+
+---
+
+# utils
+
+## executeSelection
+
+Selection Phase - UTxO Coin Selection
+
+Selects UTxOs from available pool to cover transaction outputs, fees, and change requirements.
+Handles both initial selection and reselection with retry logic up to MAX_ATTEMPTS.
+
+**Decision Flow:**
+
+```
+Calculate Required Assets
+(outputs + shortfall for fees/change)
+  ↓
+Assets Sufficient?
+(inputs >= required)
+  ├─ YES → No selection needed
+  │        (use existing explicit inputs only)
+  │        goto changeCreation
+  └─ NO → Calculate asset delta
+          ├─ Shortfall from fees? → Reselection mode
+          │  (select more lovelace for change minUTxO)
+          └─ Shortfall from outputs? → Normal selection
+             (select missing native assets or lovelace)
+          ↓
+       Perform coin selection
+       (update totalInputAssets)
+       ↓
+       Increment attempt counter
+       goto changeCreation
+```
+
+**Key Principles:**
+
+- Selection phase runs once per state machine iteration
+- Reselection (shortfall > 0) adds more UTxOs within MAX_ATTEMPTS limit
+- Selection itself doesn't fail; ChangeCreation may trigger reselection
+- No selection needed if explicit inputs already cover requirements
+- Shortfall tracks lovelace deficit for change output minUTxO
+- Asset delta identifies what additional UTxOs must contain
+- Attempt counter resets at phase start, incremented at phase end
+- Selection is deterministic (same inputs = same selection)
+
+**Signature**
+
+```ts
+export declare const executeSelection: () => Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | AvailableUtxosTag | BuildOptionsTag
+>
+```

--- a/packages/evolution/docs/modules/sdk/client/Client.ts.md
+++ b/packages/evolution/docs/modules/sdk/client/Client.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/client/Client.ts
-nav_order: 137
+nav_order: 143
 parent: Modules
 ---
 
@@ -261,9 +261,6 @@ export type ReadOnlyClient = EffectToPromiseAPI<ReadOnlyClientEffect> & {
    * - `.toTransactionWithFakeWitnesses()` - Get transaction with fake witnesses for fee validation
    * - `.estimateFee()` - Get the calculated fee
    *
-   * @param utxos - Optional UTxOs to use for coin selection. If not provided, wallet UTxOs will be fetched automatically when build() is called.
-   * @returns A new TransactionBuilder instance configured with cached protocol parameters and wallet change address.
-   *
    * @example
    * ```typescript
    * // Build unsigned transaction
@@ -282,7 +279,7 @@ export type ReadOnlyClient = EffectToPromiseAPI<ReadOnlyClientEffect> & {
    * @since 2.0.0
    * @category transaction-building
    */
-  readonly newTx: (utxos?: ReadonlyArray<UTxO.UTxO>) => TransactionBuilder<TransactionResultBase>
+  readonly newTx: (utxos?: ReadonlyArray<UTxO.UTxO>) => ReadOnlyTransactionBuilder
   // Effect namespace - includes all provider + wallet methods as Effects
   readonly Effect: ReadOnlyClientEffect
 }
@@ -453,7 +450,7 @@ export type SigningClient = EffectToPromiseAPI<SigningClientEffect> & {
    * @since 2.0.0
    * @category transaction-building
    */
-  readonly newTx: () => TransactionBuilder
+  readonly newTx: () => SigningTransactionBuilder
   // Effect namespace - includes all provider + wallet methods as Effects
   readonly Effect: SigningClientEffect
 }

--- a/packages/evolution/docs/modules/sdk/client/ClientImpl.ts.md
+++ b/packages/evolution/docs/modules/sdk/client/ClientImpl.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/client/ClientImpl.ts
-nav_order: 138
+nav_order: 144
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/provider/Blockfrost.ts.md
+++ b/packages/evolution/docs/modules/sdk/provider/Blockfrost.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Blockfrost.ts
-nav_order: 149
+nav_order: 155
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/provider/Koios.ts.md
+++ b/packages/evolution/docs/modules/sdk/provider/Koios.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Koios.ts
-nav_order: 150
+nav_order: 156
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/provider/Kupmios.ts.md
+++ b/packages/evolution/docs/modules/sdk/provider/Kupmios.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Kupmios.ts
-nav_order: 151
+nav_order: 157
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/provider/Maestro.ts.md
+++ b/packages/evolution/docs/modules/sdk/provider/Maestro.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Maestro.ts
-nav_order: 152
+nav_order: 158
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/provider/Provider.ts.md
+++ b/packages/evolution/docs/modules/sdk/provider/Provider.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/provider/Provider.ts
-nav_order: 153
+nav_order: 159
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/wallet/Derivation.ts.md
+++ b/packages/evolution/docs/modules/sdk/wallet/Derivation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/wallet/Derivation.ts
-nav_order: 159
+nav_order: 165
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/wallet/Wallet.ts.md
+++ b/packages/evolution/docs/modules/sdk/wallet/Wallet.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/wallet/Wallet.ts
-nav_order: 160
+nav_order: 166
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/sdk/wallet/WalletNew.ts.md
+++ b/packages/evolution/docs/modules/sdk/wallet/WalletNew.ts.md
@@ -1,6 +1,6 @@
 ---
 title: sdk/wallet/WalletNew.ts
-nav_order: 161
+nav_order: 167
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/utils/FeeValidation.ts.md
+++ b/packages/evolution/docs/modules/utils/FeeValidation.ts.md
@@ -1,6 +1,6 @@
 ---
 title: utils/FeeValidation.ts
-nav_order: 163
+nav_order: 169
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/utils/Hash.ts.md
+++ b/packages/evolution/docs/modules/utils/Hash.ts.md
@@ -1,6 +1,6 @@
 ---
 title: utils/Hash.ts
-nav_order: 164
+nav_order: 170
 parent: Modules
 ---
 

--- a/packages/evolution/docs/modules/utils/effect-runtime.ts.md
+++ b/packages/evolution/docs/modules/utils/effect-runtime.ts.md
@@ -1,6 +1,6 @@
 ---
 title: utils/effect-runtime.ts
-nav_order: 162
+nav_order: 168
 parent: Modules
 ---
 

--- a/packages/evolution/src/core/TransactionMetadatumLabels.ts
+++ b/packages/evolution/src/core/TransactionMetadatumLabels.ts
@@ -60,8 +60,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
    * Gets the label located at the specified index. If the index is out-of-bound,
    * returns `undefined`
    *
-   * @param index  The index of the label
-   * @returns Returns `TransactionMetadatumLabel` located at the specified index
    */
   get(index: number) {
     return this.fromLabels.at(index)
@@ -69,7 +67,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
 
   /**
    * Overrides the existing labels with the specified ones.
-   * @param overideLabels The new set of labels
    */
   set(overideLabels: Array<TransactionMetadatumLabel>) {
     while (this.fromLabels.at(0) !== undefined) {
@@ -84,8 +81,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
   /**
    * Appends a new label to the **end**
    *
-   * @param label The label to append
-   * @returns The size of the labels after appended. This is a number one higher than the previous labels count.
    */
   add(label: TransactionMetadatumLabel) {
     return this.fromLabels.push(label)
@@ -93,7 +88,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
 
   /**
    * Removes the first occurence of the specified label from the collection.
-   * @param label The label to remove from the collection
    */
   removeFirst(label: TransactionMetadatumLabel) {
     const skip = this.fromLabels.indexOf(label)
@@ -109,7 +103,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
 
   /**
    * Removes the last occurence of the specified label from the collection.
-   * @param label The label to remove from the collection
    */
   removeLast(label: TransactionMetadatumLabel) {
     const skip = this.fromLabels.lastIndexOf(label)
@@ -125,7 +118,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
 
   /**
    * Removes all occurences of the specified label from the collection.
-   * @param label The label to remove from the collection
    */
   removeAll(label: TransactionMetadatumLabel) {
     this.set(this.fromLabels.filter((fromLabel) => fromLabel !== label))
@@ -133,7 +125,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
 
   /**
    * Removes the label at the specified index from the collection.
-   * @param index The index of the label to remove from the collection
    */
   removeAt(index: number) {
     const overideLabels: Array<TransactionMetadatumLabel> = []
@@ -148,8 +139,6 @@ export class TransactionMetadatumLabels extends Schema.TaggedClass<TransactionMe
   /**
    * Determines whether the collection contains the specified label.
    *
-   * @param label The label to look for
-   * @returns True or False as appropriate
    */
   has(label: TransactionMetadatumLabel) {
     return this.fromLabels.includes(label)

--- a/packages/evolution/src/sdk/ProtocolParameters.ts
+++ b/packages/evolution/src/sdk/ProtocolParameters.ts
@@ -31,10 +31,7 @@ export type ProtocolParameters = {
 
 /**
  * Calculate the minimum fee for a transaction based on protocol parameters.
- * 
- * @param protocolParams - The current protocol parameters
- * @param txSize - The transaction size in bytes
- * @returns The minimum fee in lovelace
+ *
  */
 export const calculateMinFee = (protocolParams: ProtocolParameters, txSize: number): bigint => {
   return BigInt(protocolParams.minFeeA * txSize + protocolParams.minFeeB)
@@ -42,10 +39,7 @@ export const calculateMinFee = (protocolParams: ProtocolParameters, txSize: numb
 
 /**
  * Calculate the UTxO cost based on the protocol parameters.
- * 
- * @param protocolParams - The current protocol parameters
- * @param utxoSize - The UTxO size in bytes
- * @returns The UTxO cost in lovelace
+ *
  */
 export const calculateUtxoCost = (protocolParams: ProtocolParameters, utxoSize: number): bigint => {
   return protocolParams.coinsPerUtxoByte * BigInt(utxoSize)
@@ -53,10 +47,7 @@ export const calculateUtxoCost = (protocolParams: ProtocolParameters, utxoSize: 
 
 /**
  * Get the cost model for a specific Plutus version.
- * 
- * @param protocolParams - The current protocol parameters
- * @param version - The Plutus version
- * @returns The cost model for the specified version
+ *
  */
 export const getCostModel = (
   protocolParams: ProtocolParameters,
@@ -67,10 +58,7 @@ export const getCostModel = (
 
 /**
  * Check if the protocol parameters support a specific Plutus version.
- * 
- * @param protocolParams - The current protocol parameters
- * @param version - The Plutus version to check
- * @returns True if the version is supported
+ *
  */
 export const supportsPlutusVersion = (
   protocolParams: ProtocolParameters,

--- a/packages/evolution/src/sdk/builders/SignBuilderImpl.ts
+++ b/packages/evolution/src/sdk/builders/SignBuilderImpl.ts
@@ -37,13 +37,6 @@ type Wallet = WalletNew.SigningWallet | WalletNew.ApiWallet
 /**
  * Create a SignBuilder instance for a built transaction.
  * 
- * @param transaction - The unsigned transaction (body only, no witnesses)
- * @param transactionWithFakeWitnesses - The transaction with fake witnesses for size validation
- * @param fee - The calculated transaction fee in lovelace
- * @param utxos - The UTxOs that were used as inputs (for wallet to determine required signers)
- * @param wallet - The wallet that will sign the transaction
- * @param provider - The provider to submit the transaction to
- * 
  * @since 2.0.0
  * @category constructors
  */

--- a/packages/evolution/src/sdk/builders/SubmitBuilderImpl.ts
+++ b/packages/evolution/src/sdk/builders/SubmitBuilderImpl.ts
@@ -22,10 +22,6 @@ import { TransactionBuilderError } from "./TransactionBuilder.js"
 /**
  * Create a SubmitBuilder instance for a signed transaction.
  * 
- * @param signedTransaction - The signed transaction ready for submission
- * @param witnessSet - The witness set containing signatures
- * @param provider - The provider to submit the transaction to
- * 
  * @since 2.0.0
  * @category constructors
  */

--- a/packages/evolution/src/sdk/builders/TransactionBuilder.ts
+++ b/packages/evolution/src/sdk/builders/TransactionBuilder.ts
@@ -30,29 +30,31 @@ import type { Either } from "effect/Either"
 
 import type * as Coin from "../../core/Coin.js"
 import * as Transaction from "../../core/Transaction.js"
-import * as Assets from "../Assets.js"
+import { runEffect } from "../../utils/effect-runtime.js"
+import type * as Assets from "../Assets.js"
 import type { EvalRedeemer } from "../EvalRedeemer.js"
 import type * as Provider from "../provider/Provider.js"
 import type * as UTxO from "../UTxO.js"
 import type * as WalletNew from "../wallet/WalletNew.js"
 import type { CoinSelectionAlgorithm, CoinSelectionFunction } from "./CoinSelection.js"
-import { largestFirstSelection } from "./CoinSelection.js"
 import type { CollectFromParams, PayToAddressParams } from "./operations/Operations.js"
+import { executeBalance } from "./phases/Balance.js"
+import { executeChangeCreation } from "./phases/ChangeCreation.js"
+import { executeFallback } from "./phases/Fallback.js"
+import { executeFeeCalculation } from "./phases/FeeCalculation.js"
+import { executeSelection } from "./phases/Selection.js"
 import type { SignBuilder } from "./SignBuilder.js"
 import { makeSignBuilder } from "./SignBuilderImpl.js"
+import type { TransactionResultBase } from "./TransactionResult.js"
 import { makeTransactionResult } from "./TransactionResult.js"
 import {
   assembleTransaction,
   buildFakeWitnessSet,
   buildTransactionInputs,
-  calculateFeeIteratively,
-  calculateMinimumUtxoLovelace,
-  calculateTotalAssets,
   calculateTransactionSize,
   createCollectFromProgram,
   createPayToAddressProgram
 } from "./TxBuilderImpl.js"
-import * as Unfrack from "./Unfrack.js"
 
 /**
  * Error type for failures occurring during transaction builder operations.
@@ -65,6 +67,381 @@ export class TransactionBuilderError extends Data.TaggedError("TransactionBuilde
   cause?: unknown
 }> {}
 
+/**
+ * Build phases
+ */
+type Phase = "selection" | "changeCreation" | "feeCalculation" | "balance" | "fallback" | "complete"
+
+/**
+ * BuildContext - state machine context
+ */
+interface PhaseContext {
+  readonly phase: Phase
+  readonly attempt: number
+  readonly calculatedFee: bigint
+  readonly shortfall: bigint
+  readonly changeOutputs: ReadonlyArray<UTxO.TxOutput>
+  readonly leftoverAfterFee: Assets.Assets
+  readonly canUnfrack: boolean
+}
+
+// const PhaseContextTag = Context.GenericTag<Ref.Ref<BuildContext>>("PhaseContext")
+export class PhaseContextTag extends Context.Tag("PhaseContextTag")<PhaseContextTag, Ref.Ref<PhaseContext>>() {}
+// export class TxContext extends Context.Tag("TxContext")<TxContext, TxContextData>() {}
+
+// Initial state for transaction builder
+const initialTxBuilderState: TxBuilderState = {
+  selectedUtxos: [],
+  outputs: [],
+  scripts: new Map(),
+  totalOutputAssets: { lovelace: 0n },
+  totalInputAssets: { lovelace: 0n },
+  redeemers: new Map()
+}
+
+/**
+ * Resolve protocol parameters from options, provider, or fail.
+ * Priority: BuildOptions override > provider.getProtocolParameters() > error
+ */
+const resolveProtocolParameters = (
+  config: TxBuilderConfig,
+  options?: BuildOptions
+): Effect.Effect<ProtocolParameters, TransactionBuilderError | Provider.ProviderError> => {
+  if (options?.protocolParameters !== undefined) {
+    return Effect.succeed(options.protocolParameters)
+  }
+
+  if (config.provider) {
+    return Effect.map(
+      config.provider.Effect.getProtocolParameters(),
+      (params): ProtocolParameters => ({
+        minFeeCoefficient: BigInt(params.minFeeA),
+        minFeeConstant: BigInt(params.minFeeB),
+        coinsPerUtxoByte: params.coinsPerUtxoByte,
+        maxTxSize: params.maxTxSize
+      })
+    )
+  }
+
+  return Effect.fail(
+    new TransactionBuilderError({
+      message:
+        "No protocol parameters provided. Either provide protocolParameters in BuildOptions or provider in config.",
+      cause: null
+    })
+  )
+}
+
+/**
+ * Resolve change address from options, wallet, or fail.
+ * Priority: BuildOptions override > wallet.address() > error
+ */
+const resolveChangeAddress = (
+  config: TxBuilderConfig,
+  options?: BuildOptions
+): Effect.Effect<string, TransactionBuilderError | WalletNew.WalletError> => {
+  if (options?.changeAddress) {
+    return Effect.succeed(options.changeAddress)
+  }
+
+  if (config.wallet) {
+    return config.wallet.Effect.address()
+  }
+
+  return Effect.fail(
+    new TransactionBuilderError({
+      message: "No change address provided. Either provide wallet in config or changeAddress in build options.",
+      cause: null
+    })
+  )
+}
+
+/**
+ * Resolve available UTxOs from options, provider+wallet, or fail.
+ * Priority: BuildOptions override > provider.getUtxos(wallet.address) > error
+ */
+const resolveAvailableUtxos = (
+  config: TxBuilderConfig,
+  options?: BuildOptions
+): Effect.Effect<
+  ReadonlyArray<UTxO.UTxO>,
+  TransactionBuilderError | WalletNew.WalletError | Provider.ProviderError
+> => {
+  if (options?.availableUtxos) {
+    return Effect.succeed(options.availableUtxos)
+  }
+
+  if (config.wallet && config.provider) {
+    return Effect.flatMap(config.wallet.Effect.address(), (addr) => config.provider!.Effect.getUtxos(addr))
+  }
+
+  return Effect.fail(
+    new TransactionBuilderError({
+      message:
+        "No available UTxOs provided. Either provide wallet+provider in config or availableUtxos in build options.",
+      cause: null
+    })
+  )
+}
+
+/**
+ * Assemble final builder result based on wallet capabilities.
+ * Accesses transaction data from context tags.
+ */
+const assembleFinalResult = (
+  config: TxBuilderConfig,
+  transaction: Transaction.Transaction,
+  txWithFakeWitnesses: Transaction.Transaction
+): Effect.Effect<SignBuilder | TransactionResultBase, never, PhaseContextTag | TxContext> =>
+  Effect.gen(function* () {
+    const buildCtxRef = yield* PhaseContextTag
+    const buildCtx = yield* Ref.get(buildCtxRef)
+    const stateRef = yield* TxContext
+    const state = yield* Ref.get(stateRef)
+
+    const wallet = config.wallet
+
+    if (wallet?.type === "signing" || wallet?.type === "api") {
+      return makeSignBuilder({
+        transaction,
+        transactionWithFakeWitnesses: txWithFakeWitnesses,
+        fee: buildCtx.calculatedFee,
+        utxos: state.selectedUtxos,
+        provider: config.provider!,
+        wallet
+      })
+    }
+
+    return makeTransactionResult({
+      transaction,
+      transactionWithFakeWitnesses: txWithFakeWitnesses,
+      fee: buildCtx.calculatedFee
+    })
+  })
+
+/**
+ * Phase handler map for routing phase execution.
+ * Each handler executes its specific phase logic and returns a PhaseResult indicating the next phase.
+ * All phase implementations are now modularized in the phases/ directory.
+ */
+const phaseMap = {
+  selection: executeSelection,
+  changeCreation: executeChangeCreation,
+  feeCalculation: executeFeeCalculation,
+  balance: executeBalance,
+  fallback: executeFallback
+}
+
+/**
+ * Assemble and validate transaction after phase loop completes.
+ */
+const assembleAndValidateTransaction = Effect.gen(function* () {
+  const buildCtxRef = yield* PhaseContextTag
+  const buildCtx = yield* Ref.get(buildCtxRef)
+  const stateRef = yield* TxContext
+
+  yield* Effect.logDebug(`Build complete - fee: ${buildCtx.calculatedFee}`)
+
+  // Add change outputs to the transaction outputs
+  if (buildCtx.changeOutputs.length > 0) {
+    yield* Ref.update(stateRef, (s) => ({
+      ...s,
+      outputs: [...s.outputs, ...buildCtx.changeOutputs]
+    }))
+
+    yield* Effect.logDebug(`Added ${buildCtx.changeOutputs.length} change output(s) to transaction`)
+  }
+
+  // Get final inputs and outputs for transaction assembly
+  const finalState = yield* Ref.get(stateRef)
+  const selectedUtxos = finalState.selectedUtxos
+  const allOutputs = finalState.outputs
+
+  yield* Effect.logDebug(
+    `Assembling transaction: ${selectedUtxos.length} inputs, ${allOutputs.length} outputs, fee: ${buildCtx.calculatedFee}`
+  )
+
+  // Build transaction inputs and assemble transaction body
+  const inputs = yield* buildTransactionInputs(selectedUtxos)
+  const transaction = yield* assembleTransaction(inputs, allOutputs, buildCtx.calculatedFee)
+
+  // SAFETY CHECK: Validate transaction size against protocol limit
+  const fakeWitnessSet = yield* buildFakeWitnessSet(selectedUtxos)
+
+  const txWithFakeWitnesses = new Transaction.Transaction({
+    body: transaction.body,
+    witnessSet: fakeWitnessSet,
+    isValid: true,
+    auxiliaryData: null
+  })
+
+  const txSizeWithWitnesses = yield* calculateTransactionSize(txWithFakeWitnesses)
+  const protocolParams = yield* ProtocolParametersTag
+
+  yield* Effect.logDebug(
+    `Transaction size: ${txSizeWithWitnesses} bytes ` +
+      `(with ${fakeWitnessSet.vkeyWitnesses?.length ?? 0} fake witnesses), ` +
+      `max=${protocolParams.maxTxSize} bytes`
+  )
+
+  if (txSizeWithWitnesses > protocolParams.maxTxSize) {
+    return yield* Effect.fail(
+      new TransactionBuilderError({
+        message:
+          `Transaction size (${txSizeWithWitnesses} bytes) exceeds protocol maximum (${protocolParams.maxTxSize} bytes). ` +
+          `Consider splitting into multiple transactions.`
+      })
+    )
+  }
+
+  return { transaction, txWithFakeWitnesses }
+})
+
+const phaseStateMachine = Effect.gen(function* () {
+  // Get phase context ref once (doesn't change during execution)
+  const phaseContextRef = yield* PhaseContextTag
+
+  // Phase loop
+  while (true) {
+    const phaseContext = yield* Ref.get(phaseContextRef)
+
+    // Terminal state
+    if (phaseContext.phase === "complete") {
+      break
+    }
+
+    // Route to phase handler
+    const phase = phaseMap[phaseContext.phase]
+    if (!phase) {
+      return yield* Effect.fail(new TransactionBuilderError({ message: `Unknown phase: ${phaseContext.phase}` }))
+    }
+
+    const result = yield* phase()
+
+    // Update phase
+    yield* Ref.update(phaseContextRef, (c) => ({ ...c, phase: result.next }))
+  }
+
+  // Assemble and validate transaction
+  return yield* assembleAndValidateTransaction
+})
+
+/**
+ * Default BuildOptions for safe transaction building.
+ *
+ * **Safety Principles:**
+ * - coinSelection: "largest-first" (deterministic, efficient)
+ * - onInsufficientChange: "error" (prevents accidental fund loss)
+ * - setCollateral: 5_000_000n (5 ADA for script collateral)
+ */
+const DEFAULT_BUILD_OPTIONS = {
+  coinSelection: "largest-first",
+  onInsufficientChange: "error",
+  setCollateral: 5_000_000n
+} as const
+
+const buildEffectCore = (
+  config: TxBuilderConfig,
+  programs: Array<ProgramStep>,
+  options: BuildOptions = DEFAULT_BUILD_OPTIONS
+) =>
+  Effect.gen(function* () {
+    // Resolve all required resources
+    const protocolParameters = yield* resolveProtocolParameters(config, options)
+    const changeAddress = yield* resolveChangeAddress(config, options)
+    const availableUtxos = yield* resolveAvailableUtxos(config, options)
+
+    // Execute all programs
+    yield* Effect.all(programs, { concurrency: "unbounded" })
+
+    // Run state machine with resolved services
+    const { transaction, txWithFakeWitnesses } = yield* phaseStateMachine.pipe(
+      Effect.provideService(ProtocolParametersTag, protocolParameters),
+      Effect.provideService(ChangeAddressTag, changeAddress),
+      Effect.provideService(AvailableUtxosTag, availableUtxos)
+    )
+
+    // Assemble and return final result
+    return yield* assembleFinalResult(config, transaction, txWithFakeWitnesses)
+  }).pipe(
+    Effect.provideServiceEffect(
+      TxContext,
+      Ref.make(initialTxBuilderState)
+    ),
+    Effect.provideService(BuildOptionsTag, options),
+    Effect.provideServiceEffect(
+      PhaseContextTag,
+      Ref.make<PhaseContext>({
+        phase: "selection",
+        attempt: 0,
+        calculatedFee: 0n,
+        shortfall: 0n,
+        changeOutputs: [],
+        leftoverAfterFee: { lovelace: 0n },
+        canUnfrack: options?.unfrack !== undefined
+      })
+    )
+  )
+
+// Core Effect logic for chaining
+const chainEffectCore = (
+  config: TxBuilderConfig,
+  programs: Array<ProgramStep>,
+  _options: BuildOptions = DEFAULT_BUILD_OPTIONS
+) =>
+  Effect.gen(function* () {
+    // Chain logic: Execute programs and return intermediate state
+    return {} as ChainResult
+  }).pipe(
+    Effect.provideServiceEffect(
+      TxContext,
+      Ref.make(initialTxBuilderState)
+    ),
+    Effect.mapError(
+      (error) =>
+        new TransactionBuilderError({
+          message: "Chain failed",
+          cause: error
+        })
+    )
+  )
+
+// Core Effect logic for partial build
+const buildPartialEffectCore = (
+  config: TxBuilderConfig,
+  programs: Array<ProgramStep>,
+  _options: BuildOptions = DEFAULT_BUILD_OPTIONS
+) =>
+  Effect.gen(function* () {
+    // Execute all programs
+    yield* Effect.all(programs, { concurrency: "unbounded" })
+
+    // Return partial transaction (without evaluation)
+    return {} as Transaction.Transaction
+  }).pipe(
+    Effect.provideServiceEffect(
+      TxContext,
+      Ref.make(initialTxBuilderState)
+    ),
+    Effect.mapError(
+      (error) =>
+        new TransactionBuilderError({
+          message: "Partial build failed",
+          cause: error
+        })
+    )
+  )
+
+/**
+ * Result type for transaction chaining operations.
+ *
+ * **NOTE: NOT YET IMPLEMENTED** - This interface is reserved for future implementation
+ * of multi-transaction workflows. Current chain methods return stub implementations.
+ *
+ * @since 2.0.0
+ * @category model
+ * @experimental
+ */
 export interface ChainResult {
   readonly transaction: Transaction.Transaction
   readonly newOutputs: ReadonlyArray<UTxO.UTxO> // UTxOs created by this transaction
@@ -75,12 +452,17 @@ export interface ChainResult {
 // ============================================================================
 // Evaluator Interface - Generic abstraction for script evaluation
 // ============================================================================
+// NOTE: These interfaces are reserved for future UPLC script evaluation support.
+// The createUPLCEvaluator function currently returns dummy data and is not yet implemented.
 
 /**
  * Data required by script evaluators: cost models, execution limits, and slot configuration.
  *
+ * **NOTE: NOT YET IMPLEMENTED** - Reserved for future UPLC script evaluation support.
+ *
  * @since 2.0.0
  * @category model
+ * @experimental
  */
 export interface EvaluationContext {
   /** Cost models for script evaluation */
@@ -100,11 +482,12 @@ export interface EvaluationContext {
 /**
  * Interface for evaluating transaction scripts and computing execution units.
  *
- * When provided to builder configuration, replaces default provider-based evaluation.
- * Enables custom evaluation strategies including local UPLC execution.
+ * **NOTE: NOT YET IMPLEMENTED** - Reserved for future custom script evaluation support.
+ * When implemented, this will enable custom evaluation strategies including local UPLC execution.
  *
  * @since 2.0.0
  * @category model
+ * @experimental
  */
 export interface Evaluator {
   /**
@@ -123,8 +506,11 @@ export interface Evaluator {
 /**
  * Error type for failures in script evaluation.
  *
+ * **NOTE: NOT YET IMPLEMENTED** - Reserved for future script evaluation error handling.
+ *
  * @since 2.0.0
  * @category errors
+ * @experimental
  */
 export class EvaluationError extends Data.TaggedError("EvaluationError")<{
   readonly cause: unknown
@@ -138,8 +524,11 @@ export class EvaluationError extends Data.TaggedError("EvaluationError")<{
 /**
  * Standard UPLC evaluation function signature (matches UPLC.eval_phase_two_raw).
  *
+ * **NOTE: NOT YET IMPLEMENTED** - Reserved for future UPLC evaluation support.
+ *
  * @since 2.0.0
  * @category types
+ * @experimental
  */
 export type UPLCEvalFunction = (
   tx_bytes: Uint8Array,
@@ -155,10 +544,13 @@ export type UPLCEvalFunction = (
 
 /**
  * Creates an evaluator from a standard UPLC evaluation function.
- * The TxBuilder provides protocol parameters and cost models when calling evaluate.
+ *
+ * **NOTE: NOT YET IMPLEMENTED** - This function currently returns an evaluator
+ * that produces dummy data. Reserved for future UPLC script evaluation support.
  *
  * @since 2.0.0
  * @category evaluators
+ * @experimental
  */
 export const createUPLCEvaluator = (_evalFunction: UPLCEvalFunction): Evaluator => ({
   evaluate: (_tx: string, _additionalUtxos: ReadonlyArray<UTxO.UTxO> | undefined, _context: EvaluationContext) =>
@@ -183,7 +575,7 @@ export const createUPLCEvaluator = (_evalFunction: UPLCEvalFunction): Evaluator 
         redeemer_tag: "spend"
       }
 
-      return [dummyEvalRedeemer] as ReadonlyArray<EvalRedeemer>
+      return [dummyEvalRedeemer] as const
     })
 })
 
@@ -191,18 +583,6 @@ export const createUPLCEvaluator = (_evalFunction: UPLCEvalFunction): Evaluator 
 // Provider Integration
 // ============================================================================
 // TransactionBuilder uses the Provider interface directly
-
-/**
- * Transaction optimization flags for controlling builder behavior.
- *
- * @since 2.0.0
- * @category options
- */
-export interface TransactionOptimizations {
-  readonly mergeOutputs?: boolean
-  readonly consolidateInputs?: boolean
-  readonly minimizeFee?: boolean
-}
 
 /**
  * UTxO Optimization Options
@@ -483,18 +863,6 @@ export interface BuildOptions {
    * @default false
    */
   readonly useStateMachine?: boolean
-
-  /**
-   *
-   * When true, uses simplified 4-phase state machine:
-   * - selection → changeValidation → balanceVerification → fallback → complete
-   *
-   * shares TxContext with V2 but uses mathematical validation approach.
-   *
-   * @experimental
-   * @default false
-   */
-  readonly useV3?: boolean
 }
 
 // ============================================================================
@@ -630,13 +998,20 @@ export interface TxBuilderConfig {
  * @since 2.0.0
  * @category state
  */
+/**
+ * Mutable state for transaction building.
+ * Contains all state needed during transaction construction.
+ *
+ * @since 2.0.0
+ * @category state
+ */
 export interface TxBuilderState {
-  readonly selectedUtxos: Ref.Ref<ReadonlyArray<UTxO.UTxO>> // SDK type: Array for ordering, converted at build
-  readonly outputs: Ref.Ref<ReadonlyArray<UTxO.TxOutput>> // Transaction outputs (no txHash/outputIndex yet)
-  readonly scripts: Ref.Ref<Map<string, any>> // Scripts attached to the transaction
-  readonly totalOutputAssets: Ref.Ref<Assets.Assets> // Asset totals for balancing
-  readonly totalInputAssets: Ref.Ref<Assets.Assets> // Asset totals for balancing
-  readonly redeemers: Ref.Ref<Map<string, RedeemerData>> // Redeemer data for script inputs
+  readonly selectedUtxos: ReadonlyArray<UTxO.UTxO> // SDK type: Array for ordering, converted at build
+  readonly outputs: ReadonlyArray<UTxO.TxOutput> // Transaction outputs (no txHash/outputIndex yet)
+  readonly scripts: Map<string, any> // Scripts attached to the transaction
+  readonly totalOutputAssets: Assets.Assets // Asset totals for balancing
+  readonly totalInputAssets: Assets.Assets // Asset totals for balancing
+  readonly redeemers: Map<string, RedeemerData> // Redeemer data for script inputs
 }
 
 /**
@@ -662,20 +1037,20 @@ export interface RedeemerData {
  * @since 2.0.0
  * @category context
  */
-export interface TxContextData {
-  readonly config: TxBuilderConfig // Immutable: provider, params, available UTxOs
-  readonly state: TxBuilderState // Mutable: selected UTxOs, outputs, scripts
-  readonly options: BuildOptions // Build-specific: coin selection, evaluator, etc.
-}
-
 /**
- * Single Context service providing all transaction building data to programs.
- * Combines config (immutable), state (mutable), and options (build-specific).
+ * Combined transaction context containing all necessary data for building.
  *
  * @since 2.0.0
  * @category context
  */
-export class TxContext extends Context.Tag("TxContext")<TxContext, TxContextData>() {}
+/**
+ * Context service providing transaction building state to programs.
+ * Directly holds the mutable state Ref - config is passed as a regular parameter.
+ *
+ * @since 2.0.0
+ * @category context
+ */
+export class TxContext extends Context.Tag("TxContext")<TxContext, Ref.Ref<TxBuilderState>>() {}
 
 /**
  * Resolved change address for the current build.
@@ -719,6 +1094,15 @@ export class ProtocolParametersTag extends Context.Tag("ProtocolParameters")<
  */
 export class AvailableUtxosTag extends Context.Tag("AvailableUtxos")<AvailableUtxosTag, ReadonlyArray<UTxO.UTxO>>() {}
 
+/**
+ * Context tag providing BuildOptions for the current build.
+ * Contains build-specific configuration like unfrack, drainTo, onInsufficientChange, etc.
+ *
+ * @since 2.0.0
+ * @category context
+ */
+export class BuildOptionsTag extends Context.Tag("BuildOptions")<BuildOptionsTag, BuildOptions>() {}
+
 // ============================================================================
 // Program Step Type - Deferred Execution Pattern
 // ============================================================================
@@ -744,9 +1128,7 @@ export class AvailableUtxosTag extends Context.Tag("AvailableUtxos")<AvailableUt
  * ```
  *
  * Requirements from context:
- * - TxContext.config: Immutable configuration (provider, protocol params, available UTxOs)
- * - TxContext.state: Mutable state (selected UTxOs, outputs, scripts, assets)
- * - TxContext.options: Build options (coin selection, evaluator, collateral, etc.)
+ * - TxContext: Mutable state Ref (selected UTxOs, outputs, scripts, assets)
  *
  * @since 2.0.0
  * @category types
@@ -793,11 +1175,28 @@ export type ProgramStep = Effect.Effect<void, TransactionBuilderError, TxContext
  * @since 2.0.0
  * @category interfaces
  */
-export interface TransactionBuilder<TResult = SignBuilder> {
-  // ============================================================================
-  // Chainable Builder Methods - Create ProgramSteps, return same builder
-  // ============================================================================
 
+/**
+ * Conditional type to determine the result type based on wallet capability.
+ * - If wallet has signTx method (SigningWallet or ApiWallet): SignBuilder
+ * - Otherwise: TransactionResultBase
+ *
+ * @internal
+ */
+export type BuildResultType<W extends TxBuilderConfig["wallet"] | undefined> = W extends
+  | WalletNew.SigningWallet
+  | WalletNew.ApiWallet
+  ? SignBuilder
+  : TransactionResultBase
+
+/**
+ * Base interface for both signing and read-only transaction builders.
+ * Provides chainable builder methods common to both.
+ *
+ * @since 2.0.0
+ * @category builder-interfaces
+ */
+export interface TransactionBuilderBase {
   /**
    * Append a payment output to the transaction.
    *
@@ -807,7 +1206,7 @@ export interface TransactionBuilder<TResult = SignBuilder> {
    * @since 2.0.0
    * @category builder-methods
    */
-  readonly payToAddress: (params: PayToAddressParams) => TransactionBuilder<TResult>
+  readonly payToAddress: (params: PayToAddressParams) => this
 
   /**
    * Specify transaction inputs from provided UTxOs.
@@ -818,33 +1217,34 @@ export interface TransactionBuilder<TResult = SignBuilder> {
    * @since 2.0.0
    * @category builder-methods
    */
-  readonly collectFrom: (params: CollectFromParams) => TransactionBuilder<TResult>
+  readonly collectFrom: (params: CollectFromParams) => this
+}
 
-  // Future expansion points for other operations:
-  // readonly mintTokens: (params: MintTokensParams) => TransactionBuilder
-  // readonly delegateStake: (poolId: string) => TransactionBuilder
-  // readonly withdrawRewards: (amount?: Coin.Coin) => TransactionBuilder
-  // readonly addMetadata: (label: string | number, metadata: any) => TransactionBuilder
-  // readonly setValidityInterval: (start?: number, end?: number) => TransactionBuilder
-
-  // ============================================================================
-  // Hybrid Completion Methods - Execute Programs with Fresh State
-  // ============================================================================
-
+/**
+ * Transaction builder for signing wallets (SigningWallet or ApiWallet).
+ *
+ * Builds transactions that can be signed. The build() method returns a SignBuilder
+ * which provides sign(), signWithWitness(), and other signing capabilities.
+ *
+ * This builder type is returned when makeTxBuilder() is called with a signing wallet.
+ * Type narrowing happens automatically at construction time - no call-site guards needed.
+ *
+ * @since 2.0.0
+ * @category builder-interfaces
+ */
+export interface SigningTransactionBuilder extends TransactionBuilderBase {
   /**
    * Execute all queued operations and return a signing-ready transaction via Promise.
    *
    * Creates fresh state and runs all accumulated ProgramSteps sequentially.
    * Can be called multiple times on the same builder instance with independent results.
    *
-   * Returns TResult which is:
-   * - SignBuilder for SigningClient (can sign transactions)
-   * - TransactionResultBase for ReadOnlyClient (unsigned transaction only)
+   * @returns Promise<SignBuilder> which provides signing capabilities
    *
    * @since 2.0.0
    * @category completion-methods
    */
-  readonly build: (options?: BuildOptions) => Promise<TResult>
+  readonly build: (options?: BuildOptions) => Promise<SignBuilder>
 
   /**
    * Execute all queued operations and return a signing-ready transaction via Effect.
@@ -852,11 +1252,7 @@ export interface TransactionBuilder<TResult = SignBuilder> {
    * Creates fresh state and runs all accumulated ProgramSteps sequentially.
    * Suitable for Effect-TS compositional workflows and error handling.
    *
-   * Error types include WalletError and ProviderError from config Effects.
-   *
-   * Returns TResult which is:
-   * - SignBuilder for SigningClient (can sign transactions)
-   * - TransactionResultBase for ReadOnlyClient (unsigned transaction only)
+   * @returns Effect<SignBuilder, ...> which provides signing capabilities
    *
    * @since 2.0.0
    * @category completion-methods
@@ -864,22 +1260,18 @@ export interface TransactionBuilder<TResult = SignBuilder> {
   readonly buildEffect: (
     options?: BuildOptions
   ) => Effect.Effect<
-    TResult,
+    SignBuilder,
     TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError,
-    unknown
+    never
   >
 
   /**
    * Execute all queued operations with explicit error handling via Either.
    *
    * Creates fresh state and runs all accumulated ProgramSteps sequentially.
-   * Returns Either<TResult, Error> for pattern-matched error recovery.
+   * Returns Either<Result, Error> for pattern-matched error recovery.
    *
-   * Error types include WalletError and ProviderError from config Effects.
-   *
-   * Returns TResult which is:
-   * - SignBuilder for SigningClient (can sign transactions)
-   * - TransactionResultBase for ReadOnlyClient (unsigned transaction only)
+   * @returns Promise<Either<SignBuilder, Error>>
    *
    * @since 2.0.0
    * @category completion-methods
@@ -887,80 +1279,96 @@ export interface TransactionBuilder<TResult = SignBuilder> {
   readonly buildEither: (
     options?: BuildOptions
   ) => Promise<
-    Either<TResult, TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError>
+    Either<SignBuilder, TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError>
   >
-
-  // ============================================================================
-  // Transaction Chaining Methods - Multi-transaction workflows
-  // ============================================================================
-
-  /**
-   * Execute queued operations and return result for multi-transaction workflows via Promise.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns ChainResult containing the transaction,
-   * new UTxOs, and updated available UTxOs for subsequent transactions.
-   *
-   * @since 2.0.0
-   * @category chaining-methods
-   */
-  readonly chain: (options?: BuildOptions) => Promise<ChainResult>
-
-  /**
-   * Execute queued operations and return result for multi-transaction workflows via Effect.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns ChainResult for Effect-TS workflows
-   * and composable error handling.
-   *
-   * @since 2.0.0
-   * @category chaining-methods
-   */
-  readonly chainEffect: (
-    options?: BuildOptions
-  ) => Effect.Effect<ChainResult, TransactionBuilderError | EvaluationError>
-
-  /**
-   * Execute queued operations with explicit error handling via Either for multi-transaction workflows.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns Either<ChainResult, Error>
-   * for pattern-matched error recovery in transaction sequences.
-   *
-   * @since 2.0.0
-   * @category chaining-methods
-   */
-  readonly chainEither: (
-    options?: BuildOptions
-  ) => Promise<Either<ChainResult, TransactionBuilderError | EvaluationError>>
-
-  // ============================================================================
-  // Debug Methods - Inspect transaction state during development
-  // ============================================================================
-
-  /**
-   * Execute queued operations without script evaluation or finalization; return partial transaction via Promise.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns intermediate transaction for inspection.
-   * Useful for debugging transaction assembly and coin selection logic.
-   *
-   * @since 2.0.0
-   * @category debug-methods
-   */
-  readonly buildPartial: () => Promise<Transaction.Transaction>
-
-  /**
-   * Execute queued operations without script evaluation or finalization; return partial transaction via Effect.
-   *
-   * Creates fresh state and runs all ProgramSteps. Returns intermediate transaction for inspection.
-   * Suitable for Effect-TS workflows requiring transaction debugging.
-   *
-   * @since 2.0.0
-   * @category debug-methods
-   */
-  readonly buildPartialEffect: () => Effect.Effect<Transaction.Transaction, TransactionBuilderError, unknown>
 }
 
-// ============================================================================
-// Factory Function - Creates TransactionBuilder instances
-// ============================================================================
+/**
+ * Transaction builder for read-only wallets (ReadOnlyWallet or undefined).
+ *
+ * Builds transactions that cannot be signed. The build() method returns a TransactionResultBase
+ * which provides query methods like toTransaction() but NOT signing capabilities.
+ *
+ * This builder type is returned when makeTxBuilder() is called with a read-only wallet or no wallet.
+ * Type narrowing happens automatically at construction time - no call-site guards needed.
+ *
+ * @since 2.0.0
+ * @category builder-interfaces
+ */
+export interface ReadOnlyTransactionBuilder extends TransactionBuilderBase {
+  /**
+   * Execute all queued operations and return a transaction result via Promise.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Can be called multiple times on the same builder instance with independent results.
+   *
+   * @returns Promise<TransactionResultBase> which provides query-only methods
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly build: (options?: BuildOptions) => Promise<TransactionResultBase>
+
+  /**
+   * Execute all queued operations and return a transaction result via Effect.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Suitable for Effect-TS compositional workflows and error handling.
+   *
+   * @returns Effect<TransactionResultBase, ...> which provides query-only methods
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly buildEffect: (
+    options?: BuildOptions
+  ) => Effect.Effect<
+    TransactionResultBase,
+    TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError,
+    never
+  >
+
+  /**
+   * Execute all queued operations with explicit error handling via Either.
+   *
+   * Creates fresh state and runs all accumulated ProgramSteps sequentially.
+   * Returns Either<Result, Error> for pattern-matched error recovery.
+   *
+   * @returns Promise<Either<TransactionResultBase, Error>>
+   *
+   * @since 2.0.0
+   * @category completion-methods
+   */
+  readonly buildEither: (
+    options?: BuildOptions
+  ) => Promise<
+    Either<
+      TransactionResultBase,
+      TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError
+    >
+  >
+}
+
+/**
+ * Union type for all transaction builders.
+ * Use specific types (SigningTransactionBuilder or ReadOnlyTransactionBuilder) when you know the wallet type.
+ *
+ * @since 2.0.0
+ * @category builder-interfaces
+ */
+export type TransactionBuilder = SigningTransactionBuilder | ReadOnlyTransactionBuilder
+
+/**
+ * Conditional type to determine the correct TransactionBuilder based on wallet type.
+ * - If wallet is SigningWallet or ApiWallet: SigningTransactionBuilder
+ * - If wallet is ReadOnlyWallet or undefined: ReadOnlyTransactionBuilder
+ *
+ * @internal
+ */
+export type TxBuilderResultType<
+  W extends WalletNew.SigningWallet | WalletNew.ApiWallet | WalletNew.ReadOnlyWallet | undefined
+> = W extends WalletNew.SigningWallet | WalletNew.ApiWallet ? SigningTransactionBuilder : ReadOnlyTransactionBuilder
+
 
 /**
  * Construct a TransactionBuilder instance from protocol configuration.
@@ -969,1072 +1377,27 @@ export interface TransactionBuilder<TResult = SignBuilder> {
  * creates fresh state (new Refs) and executes all accumulated programs sequentially, ensuring
  * no state pollution between invocations.
  *
- * Generic type parameter TResult determines what build() returns:
- * - SignBuilder (default): When wallet has signing capability
- * - TransactionResultBase: When wallet is read-only
+ * The return type is determined by the actual wallet provided using conditional types:
+ * - SigningTransactionBuilder: When wallet is SigningWallet or ApiWallet
+ * - ReadOnlyTransactionBuilder: When wallet is ReadOnlyWallet or undefined
  *
- * @typeParam TResult - The result type for build() methods (SignBuilder or TransactionResultBase)
+ * Wallet type narrowing happens at construction time based on the wallet's actual type.
+ * No call-site type narrowing or type guards needed.
+ *
+ * Wallet parameter is optional; if omitted, changeAddress and availableUtxos must be
+ * provided at build time via BuildOptions.
  *
  * @since 2.0.0
  * @category constructors
+ *
  */
-export const makeTxBuilder = <TResult = SignBuilder>(config: TxBuilderConfig): TransactionBuilder<TResult> => {
-  // Protocol parameters validation is deferred to build time when they are resolved
-  // (from BuildOptions > config > provider)
-
-  // ProgramSteps array - stores deferred operations
-  // NO state created here - state is fresh per build()
+export function makeTxBuilder<
+  W extends WalletNew.SigningWallet | WalletNew.ApiWallet | WalletNew.ReadOnlyWallet | undefined
+>(config: Partial<TxBuilderConfig> & { wallet?: W }): TxBuilderResultType<W>
+export function makeTxBuilder(config: TxBuilderConfig) {
   const programs: Array<ProgramStep> = []
 
-  // Helper: Get coin selection algorithm function from name
-  const getCoinSelectionAlgorithm = (algorithm: CoinSelectionAlgorithm): CoinSelectionFunction => {
-    switch (algorithm) {
-      case "largest-first":
-        return largestFirstSelection
-      case "random-improve":
-        throw new TransactionBuilderError({
-          message: "random-improve algorithm not yet implemented",
-          cause: { algorithm }
-        })
-      case "optimal":
-        throw new TransactionBuilderError({
-          message: "optimal algorithm not yet implemented",
-          cause: { algorithm }
-        })
-      default:
-        throw new TransactionBuilderError({
-          message: `Unknown coin selection algorithm: ${algorithm}`,
-          cause: { algorithm }
-        })
-    }
-  }
-
-  // Helper: Create fresh state Effect
-  const createFreshState = () =>
-    Effect.gen(function* () {
-      return {
-        selectedUtxos: yield* Ref.make<ReadonlyArray<UTxO.UTxO>>([]), // Array for ordering
-        outputs: yield* Ref.make<ReadonlyArray<any>>([]),
-        scripts: yield* Ref.make(new Map<string, any>()),
-        totalOutputAssets: yield* Ref.make<Assets.Assets>({ lovelace: 0n }),
-        totalInputAssets: yield* Ref.make<Assets.Assets>({ lovelace: 0n }),
-        redeemers: yield* Ref.make(new Map<string, RedeemerData>())
-      }
-    })
-
-  /**
-   * Helper: Format assets for logging (BigInt-safe, truncates long unit names)
-   */
-  const formatAssetsForLog = (assets: Assets.Assets): string => {
-    return Object.entries(assets)
-      .map(([unit, amount]) => `${unit.substring(0, 16)}...: ${amount.toString()}`)
-      .join(", ")
-  }
-
-  /**
-   * Helper: Create unfracked change outputs (multiple outputs)
-   * Only called when unfrack option is enabled.
-   * Returns change outputs array or undefined if unfrack is not viable.
-   *
-   * @param leftoverAfterFee - Tentative leftover calculated with previous fee estimate
-   * @param ctx - Transaction context data
-   * @param changeAddress - Resolved change address for this build
-   * @returns ReadonlyArray<TxOutput> or undefined if not viable
-   */
-  const createChangeOutputs = (
-    leftoverAfterFee: Assets.Assets,
-    ctx: TxContextData,
-    changeAddress: string,
-    coinsPerUtxoByte: bigint
-  ): Effect.Effect<ReadonlyArray<UTxO.TxOutput>, TransactionBuilderError> =>
-    Effect.gen(function* () {
-      // Empty leftover = no change needed
-      if (Assets.isEmpty(leftoverAfterFee)) {
-        return []
-      }
-
-      // Create unfracked outputs with proper minUTxO calculation
-      const unfrackOptions = ctx.options!.unfrack! // Safe: only called when unfrack is enabled
-
-      const changeOutputs = yield* Unfrack.createUnfrackedChangeOutputs(
-        changeAddress,
-        leftoverAfterFee,
-        unfrackOptions,
-        coinsPerUtxoByte
-      ).pipe(
-        Effect.mapError(
-          (err) =>
-            new TransactionBuilderError({
-              message: `Failed to create unfracked change outputs: ${err.message}`,
-              cause: err
-            })
-        )
-      )
-
-      yield* Effect.logDebug(`[ChangeCreationV2] Created ${changeOutputs.length} unfracked change outputs`)
-
-      return changeOutputs
-    })
-
-  // ============================================================================
-  // Coin Selection Helper Functions
-  // ============================================================================
-
-  /**
-   * Get UTxOs that haven't been selected yet.
-   * Uses Set for O(1) lookup instead of O(n) for better performance.
-   */
-  const getAvailableUtxos = (
-    allUtxos: ReadonlyArray<UTxO.UTxO>,
-    selectedUtxos: ReadonlyArray<UTxO.UTxO>
-  ): ReadonlyArray<UTxO.UTxO> => {
-    const selectedKeys = new Set(selectedUtxos.map((u) => `${u.txHash}:${u.outputIndex}`))
-    return allUtxos.filter((utxo) => !selectedKeys.has(`${utxo.txHash}:${utxo.outputIndex}`))
-  }
-
-  /**
-   * Resolve coin selection function from options.
-   * Returns the configured algorithm or defaults to largest-first.
-   */
-  const resolveCoinSelectionFn = (
-    coinSelection?: CoinSelectionAlgorithm | CoinSelectionFunction
-  ): CoinSelectionFunction => {
-    if (!coinSelection) return largestFirstSelection
-    if (typeof coinSelection === "function") return coinSelection
-    return getCoinSelectionAlgorithm(coinSelection)
-  }
-
-  /**
-   * Add selected UTxOs to transaction context state.
-   * Updates both the selected UTxOs list and total input assets.
-   */
-  const addUtxosToState = (selectedUtxos: ReadonlyArray<UTxO.UTxO>): Effect.Effect<void, never, TxContext> =>
-    Effect.gen(function* () {
-      const ctx = yield* TxContext
-
-      // Log each UTxO being added
-      for (const utxo of selectedUtxos) {
-        const txHash = utxo.txHash
-        const outputIndex = utxo.outputIndex
-        yield* Effect.logDebug(`[Selection] Adding UTxO: ${txHash}#${outputIndex}, ${formatAssetsForLog(utxo.assets)}.`)
-      }
-
-      // Add to selected UTxOs list
-      yield* Ref.update(ctx.state.selectedUtxos, (current) => [...current, ...selectedUtxos])
-
-      // Calculate total assets from selected UTxOs and add to input assets
-      const additionalAssets = calculateTotalAssets(selectedUtxos)
-      yield* Ref.update(ctx.state.totalInputAssets, (current) => {
-        return Assets.add(current, additionalAssets)
-      })
-    })
-
-  /**
-   * Helper: Perform coin selection and update TxContext.state
-   */
-  const performCoinSelectionUpdateState = (assetShortfalls: Assets.Assets) =>
-    Effect.gen(function* () {
-      const ctx = yield* TxContext
-      const alreadySelected = yield* Ref.get(ctx.state.selectedUtxos)
-
-      // Get resolved availableUtxos from context tag
-      const allAvailableUtxos = yield* AvailableUtxosTag
-      const availableUtxos = getAvailableUtxos(allAvailableUtxos, alreadySelected)
-      const coinSelectionFn = resolveCoinSelectionFn(ctx.options?.coinSelection)
-
-      const { selectedUtxos } = yield* Effect.try({
-        try: () => coinSelectionFn(availableUtxos, assetShortfalls),
-        catch: (error) => {
-          // Custom serialization for Assets (handles BigInt)
-          return new TransactionBuilderError({
-            message: `Coin selection failed for ${formatAssetsForLog(assetShortfalls)}`,
-            cause: error
-          })
-        }
-      })
-
-      yield* addUtxosToState(selectedUtxos)
-    })
-
-  // ============================================================================
-  // State Machine Implementation - Mathematical Validation Approach
-  // ============================================================================
-
-  /**
-   * Build phases
-   */
-  type Phase = "selection" | "changeCreation" | "feeCalculation" | "balance" | "fallback" | "complete"
-
-  /**
-   * BuildContext - state machine context
-   */
-  interface BuildContext {
-    readonly phase: Phase
-    readonly attempt: number
-    readonly calculatedFee: bigint
-    readonly shortfall: bigint
-    readonly changeOutputs: ReadonlyArray<UTxO.TxOutput>
-    readonly leftoverAfterFee: Assets.Assets
-    readonly canUnfrack: boolean
-  }
-
-  const BuildContextTag = Context.GenericTag<Ref.Ref<BuildContext>>("V3BuildContext")
-
-  interface PhaseResult {
-    readonly next: Phase
-  }
-
-  const phaseSelectionV3 = Effect.gen(function* () {
-    const ctx = yield* TxContext
-    const buildCtxRef = yield* BuildContextTag
-    const buildCtx = yield* Ref.get(buildCtxRef)
-
-    const inputAssets = yield* Ref.get(ctx.state.totalInputAssets)
-    const outputAssets = yield* Ref.get(ctx.state.totalOutputAssets)
-
-    // Step 3: Calculate total needed (outputs + shortfall)
-    // Shortfall contains fee + any missing lovelace for change outputs
-    const totalNeeded: Assets.Assets = {
-      ...outputAssets,
-      lovelace: outputAssets.lovelace + buildCtx.shortfall
-    }
-
-    // Step 4: Calculate asset delta & extract shortfalls
-    const assetDelta = Assets.subtract(totalNeeded, inputAssets)
-    const assetShortfalls = Assets.filter(assetDelta, (_unit, amount) => amount > 0n)
-
-    // During reselection (shortfall > 0), we need to select MORE lovelace
-    // even if inputAssets >= totalNeeded, because the shortfall indicates
-    // insufficient lovelace for change output minUTxO requirement
-    const isReselection = buildCtx.shortfall > 0n
-    const needsSelection = !Assets.isEmpty(assetShortfalls) || isReselection
-
-    yield* Effect.logDebug(
-      `[SelectionV3] Needed: {${formatAssetsForLog(totalNeeded)}}, ` +
-        `Available: {${formatAssetsForLog(inputAssets)}}, ` +
-        `Delta: {${formatAssetsForLog(assetDelta)}}` +
-        (isReselection ? `, Reselection: shortfall=${buildCtx.shortfall}` : "")
-    )
-
-    // Step 5: Perform selection or skip
-    if (!needsSelection) {
-      yield* Effect.logDebug("[SelectionV3] Assets sufficient")
-      const selectedUtxos = yield* Ref.get(ctx.state.selectedUtxos)
-      yield* Effect.logDebug(
-        `[SelectionV3] No selection needed: ${selectedUtxos.length} UTxO(s) already available from explicit inputs (collectFrom), ` +
-          `Total lovelace: ${inputAssets.lovelace || 0n}`
-      )
-    } else {
-      if (isReselection) {
-        yield* Effect.logDebug(
-          `[SelectionV3] Reselection attempt ${buildCtx.attempt + 1}: ` +
-            `Need ${buildCtx.shortfall} more lovelace for change minUTxO`
-        )
-        // During reselection, select for the shortfall amount only
-        const reselectionShortfall: Assets.Assets = { lovelace: buildCtx.shortfall }
-        yield* performCoinSelectionUpdateState(reselectionShortfall)
-      } else {
-        yield* Effect.logDebug(`[SelectionV3] Selecting for shortfall: ${formatAssetsForLog(assetShortfalls)}`)
-        yield* performCoinSelectionUpdateState(assetShortfalls)
-      }
-    }
-
-    // Step 6: Update context and proceed
-    yield* Ref.update(buildCtxRef, (ctx) => ({ ...ctx, attempt: ctx.attempt + 1, shortfall: 0n }))
-
-    return { next: "changeCreation" as Phase }
-  })
-
-  /**
-   * Change Creation Phase
-   *
-   * Creates change outputs from leftover assets using a cascading retry strategy.
-   * Both unfrack (N outputs) and single output follow the same retry pattern:
-   * try with available funds → if insufficient, reselect (up to MAX_ATTEMPTS) → fallback.
-   *
-   * **Symmetric Retry Flow (Unfrack vs Single Output):**
-   * ```
-   * UNFRACK (N outputs)                    SINGLE OUTPUT (1 output)
-   * ─────────────────────────────────────────────────────────────────
-   *
-   * Try: Create N outputs                  Try: Create 1 output
-   * ↓                                      ↓
-   * Check: leftover >= (minUTxO × N)?      Check: leftover >= minUTxO?
-   * ↓                                      ↓
-   * If NO (not affordable):                If NO (insufficient):
-   *   ├─ attempt < MAX? → Reselect           ├─ attempt < MAX? → Reselect
-   *   └─ attempt >= MAX? → Fallback          └─ attempt >= MAX? → Fallback
-   *                                                               ↓
-   * Fallback:                              Fallback:
-   *   └─ Single output                       ├─ drainTo (merge into output)
-   *       ├─ (retry/fallback)                ├─ burn (leftover → fee)
-   *       └─ ...                             └─ error
-   * ```
-   *
-   * **Detailed Flow:**
-   * ```
-   * 1. Calculate tentative leftover (inputs - outputs - contextFee)
-   *
-   * 2. If unfrack enabled and canUnfrack=true:
-   *    → Try createUnfrackedChangeOutputs() (N outputs)
-   *    → Success: store N outputs, goto FeeCalculation
-   *    → Not affordable:
-   *       ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
-   *       └─ If attempt >= MAX_ATTEMPTS: canUnfrack=false, goto step 3
-   *
-   * 3. Single output approach:
-   *    → Create 1 change output with leftover
-   *    → Success: store 1 output, goto FeeCalculation
-   *    → Not affordable:
-   *       ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
-   *       └─ If attempt >= MAX_ATTEMPTS: goto step 4
-   *
-   * 4. Insufficient change fallbacks (single-output only):
-   *    a. If drainTo specified: merge into existing output
-   *    b. If onInsufficientChange="burn": leftover becomes fee
-   *    c. If onInsufficientChange="error": throw error
-   * ```
-   *
-   * **Key Principles:**
-   * - Unfrack and single output use SAME retry mechanism (reselection up to MAX_ATTEMPTS)
-   * - Phase loop handles fee convergence (leftover recalculated each iteration)
-   * - Last subdivision output absorbs remainder for exact balance
-   * - canUnfrack flag prevents retry loops (once false, stays false)
-   * - drainTo and burn are terminal fallbacks (single-output only)
-   * - Unfrack outputs bypass drainTo/burn (they're already valid)
-   *
-   * @returns Next phase to transition to
-   */
-  const phaseChangeCreationV3 = Effect.gen(function* () {
-    const ctx = yield* TxContext
-    const buildCtxRef = yield* BuildContextTag
-    const buildCtx = yield* Ref.get(buildCtxRef)
-    const changeAddress = yield* ChangeAddressTag
-
-    yield* Effect.logDebug(`[ChangeCreationV3] Fee from context: ${buildCtx.calculatedFee}`)
-
-    // Step 2: Calculate leftover assets
-    const inputAssets = yield* Ref.get(ctx.state.totalInputAssets)
-    const outputAssets = yield* Ref.get(ctx.state.totalOutputAssets)
-    const leftoverBeforeFee = Assets.subtract(inputAssets, outputAssets)
-
-    const tentativeLeftover: Assets.Assets = {
-      ...leftoverBeforeFee,
-      lovelace: leftoverBeforeFee.lovelace - buildCtx.calculatedFee
-    }
-
-    // Step 3: Check if negative - return to selection immediately
-    // TODO: Verify this scenario is tested - negative tentativeLeftover on attempt > 0
-    if (tentativeLeftover.lovelace < 0n) {
-      const shortfall = -tentativeLeftover.lovelace
-
-      yield* Effect.logDebug(
-        `[ChangeCreationV3] Insufficient lovelace for fee: ${tentativeLeftover.lovelace}. ` +
-          `Shortfall: ${shortfall}. Returning to selection.`
-      )
-
-      yield* Ref.update(buildCtxRef, (ctx) => ({
-        ...ctx,
-        shortfall,
-        changeOutputs: []
-      }))
-      return { next: "selection" as Phase }
-    }
-
-    // Step 4: Affordability check - verify minimum (single output) is affordable
-    // This pre-flight check ensures we can create at least one valid change output
-    // before attempting any unfrack strategies
-    const protocolParams = yield* ProtocolParametersTag
-    const minLovelaceForSingle = yield* calculateMinimumUtxoLovelace({
-      address: changeAddress,
-      assets: tentativeLeftover,
-      coinsPerUtxoByte: protocolParams.coinsPerUtxoByte
-    })
-
-    if (tentativeLeftover.lovelace < minLovelaceForSingle) {
-      // Not even affordable for single output - trigger reselection
-      const shortfall = minLovelaceForSingle - tentativeLeftover.lovelace
-      const buildCtx = yield* Ref.get(buildCtxRef)
-      const MAX_ATTEMPTS = 3
-
-      // Check if leftover is ADA-only (no native assets)
-      const isAdaOnlyLeftover = Object.keys(tentativeLeftover).length === 1 // Only "lovelace" key
-
-      // Check if we have available UTxOs for reselection
-      const alreadySelected = yield* Ref.get(ctx.state.selectedUtxos)
-      const allAvailableUtxos = yield* AvailableUtxosTag
-      const availableUtxos = getAvailableUtxos(allAvailableUtxos, alreadySelected)
-      const hasMoreUtxos = availableUtxos.length > 0
-
-      // Try reselection up to MAX_ATTEMPTS (if UTxOs available)
-      if (hasMoreUtxos && buildCtx.attempt < MAX_ATTEMPTS) {
-        yield* Effect.logDebug(
-          `[ChangeCreationV3] Leftover ${tentativeLeftover.lovelace} < ${minLovelaceForSingle} minUTxO ` +
-            `(shortfall: ${shortfall}${isAdaOnlyLeftover ? ", ADA-only" : ", with native assets"}). ` +
-            `Attempting reselection (${buildCtx.attempt + 1}/${MAX_ATTEMPTS})`
-        )
-
-        yield* Ref.update(buildCtxRef, (ctx) => ({
-          ...ctx,
-          shortfall,
-          changeOutputs: []
-        }))
-
-        return { next: "selection" as Phase }
-      }
-
-      // No more UTxOs OR MAX_ATTEMPTS exhausted - check fallback options
-      yield* Effect.logDebug(
-        `[ChangeCreationV3] Cannot reselect: ${!hasMoreUtxos ? "No more UTxOs available" : `MAX_ATTEMPTS (${MAX_ATTEMPTS}) exhausted`}. ` +
-          `Leftover (before fee): ${formatAssetsForLog(tentativeLeftover)}, minUTxO: ${minLovelaceForSingle}`
-      )
-
-      // CASE 1: Native assets present - cannot use drain/burn fallback
-      if (!isAdaOnlyLeftover) {
-        return yield* Effect.fail(
-          new TransactionBuilderError({
-            message:
-              `Cannot balance transaction: Native assets present in leftover ` +
-              `but insufficient lovelace (${tentativeLeftover.lovelace} < ${minLovelaceForSingle} minUTxO) ` +
-              `after ${buildCtx.attempt} selection attempts.\n\n` +
-              `Your leftover includes native assets (tokens) which require at least ` +
-              `${minLovelaceForSingle} lovelace to create a valid change output, but only ` +
-              `${tentativeLeftover.lovelace} lovelace remains.\n\n` +
-              `Solutions:\n` +
-              `1. Include the native assets in your payment outputs\n` +
-              `2. Add more lovelace to your wallet\n` +
-              `3. Use fewer/smaller outputs to reduce fees`,
-            cause: undefined
-          })
-        )
-      }
-
-      // CASE 2: ADA-only leftover - check if fallback strategies are configured
-      const hasFallbackStrategy = ctx.options?.drainTo !== undefined || ctx.options?.onInsufficientChange === "burn"
-
-      if (!hasFallbackStrategy) {
-        // No fallback configured - fail with clear user-facing error
-        return yield* Effect.fail(
-          new TransactionBuilderError({
-            message:
-              `Cannot create valid change: Insufficient funds to cover payment, fees, and minimum UTxO requirements.\n\n` +
-              `Available: ${tentativeLeftover.lovelace} lovelace\n` +
-              `Required: At least ${minLovelaceForSingle} lovelace for change output\n\n` +
-              `Solutions:\n` +
-              `1. Add more funds to your wallet\n` +
-              `2. Reduce payment amounts or number of outputs\n` +
-              `3. Use drainTo(index) to merge leftover with an existing output\n` +
-              `4. Use onInsufficientChange: 'burn' to explicitly burn leftover as extra fee`,
-            cause: undefined
-          })
-        )
-      }
-
-      // Fallback strategies configured - proceed to Fallback phase
-      return { next: "fallback" as Phase }
-    }
-
-    // Step 5: Unfrack path (single output IS affordable, try bundles/subdivision)
-    if (ctx.options?.unfrack && buildCtx.canUnfrack) {
-      const protocolParams = yield* ProtocolParametersTag
-      const changeOutputs = yield* createChangeOutputs(
-        tentativeLeftover,
-        ctx,
-        changeAddress,
-        protocolParams.coinsPerUtxoByte
-      )
-
-      yield* Effect.logDebug(`[ChangeCreationV3] Successfully created ${changeOutputs.length} unfracked outputs`)
-
-      // Store outputs and proceed to fee calculation
-      yield* Ref.update(buildCtxRef, (ctx) => ({
-        ...ctx,
-        changeOutputs
-      }))
-      return { next: "feeCalculation" as Phase }
-    }
-
-    // Step 6: Single output path - create single change output
-    // Affordability already verified in Step 4, so we can create output directly
-    const singleOutput: UTxO.TxOutput = {
-      address: changeAddress,
-      assets: tentativeLeftover,
-      datumOption: undefined,
-      scriptRef: undefined
-    }
-
-    yield* Ref.update(buildCtxRef, (ctx) => ({
-      ...ctx,
-      changeOutputs: [singleOutput]
-    }))
-
-    return { next: "feeCalculation" as Phase }
-  })
-
-  const phaseFeeCalculationV3 = Effect.gen(function* () {
-    // Step 1: Get contexts and current state
-    const ctx = yield* TxContext
-    const buildCtxRef = yield* BuildContextTag
-    const buildCtx = yield* Ref.get(buildCtxRef)
-
-    const selectedUtxos = yield* Ref.get(ctx.state.selectedUtxos)
-    const baseOutputs = yield* Ref.get(ctx.state.outputs)
-
-    // Step 2: Build transaction inputs
-    const inputs = yield* buildTransactionInputs(selectedUtxos)
-
-    // Step 3: Combine base outputs + change outputs
-    yield* Effect.logDebug(
-      `[FeeCalculationV3] Starting fee calculation with ${baseOutputs.length} base outputs + ${buildCtx.changeOutputs.length} change outputs`
-    )
-
-    const allOutputs = [...baseOutputs, ...buildCtx.changeOutputs]
-
-    // Step 4: Calculate fee WITH change outputs
-    const protocolParams = yield* ProtocolParametersTag
-    const calculatedFee = yield* calculateFeeIteratively(selectedUtxos, inputs, allOutputs, {
-      minFeeCoefficient: protocolParams.minFeeCoefficient,
-      minFeeConstant: protocolParams.minFeeConstant
-    })
-
-    yield* Effect.logDebug(`[FeeCalculationV3] Calculated fee: ${calculatedFee}`)
-
-    // Step 5: Calculate leftover after fee NOW (after fee is known)
-    const inputAssets = yield* Ref.get(ctx.state.totalInputAssets)
-    const outputAssets = yield* Ref.get(ctx.state.totalOutputAssets)
-    const leftoverBeforeFee = Assets.subtract(inputAssets, outputAssets)
-
-    const leftoverAfterFee: Assets.Assets = {
-      ...leftoverBeforeFee,
-      lovelace: leftoverBeforeFee.lovelace - calculatedFee
-    }
-
-    // Step 6: Store both fee and leftoverAfterFee in context
-    yield* Ref.update(buildCtxRef, (ctx) => ({
-      ...ctx,
-      calculatedFee,
-      leftoverAfterFee
-    }))
-
-    return { next: "balance" as Phase }
-  })
-
-  const phaseBalanceV3 = Effect.gen(function* () {
-    // Step 1: Get contexts and log start
-    const ctx = yield* TxContext
-    const buildCtxRef = yield* BuildContextTag
-    const buildCtx = yield* Ref.get(buildCtxRef)
-
-    yield* Effect.logDebug(`[BalanceV3] Starting balance verification (attempt ${buildCtx.attempt})`)
-
-    // Step 2: Calculate delta = inputs - outputs - change - fee
-    const inputAssets = yield* Ref.get(ctx.state.totalInputAssets)
-    const outputAssets = yield* Ref.get(ctx.state.totalOutputAssets)
-
-    // Calculate total change assets
-    const changeAssets = buildCtx.changeOutputs.reduce((acc, output) => Assets.merge(acc, output.assets), {
-      lovelace: 0n
-    } as Assets.Assets)
-
-    // Delta = inputs - outputs - change - fee
-    let delta = Assets.subtract(inputAssets, outputAssets)
-    delta = Assets.subtract(delta, changeAssets)
-    delta = { ...delta, lovelace: delta.lovelace - buildCtx.calculatedFee }
-
-    // Check if balanced: lovelace must be exactly 0 and all native assets must be 0
-    const isBalanced = delta.lovelace === 0n
-
-    yield* Effect.logDebug(
-      `[BalanceV3] Inputs: ${formatAssetsForLog(inputAssets)}, ` +
-        `Outputs: ${formatAssetsForLog(outputAssets)}, ` +
-        `Change: ${formatAssetsForLog(changeAssets)}, ` +
-        `Fee: ${buildCtx.calculatedFee}, ` +
-        `Delta: ${formatAssetsForLog(delta)}, ` +
-        `Balanced: ${isBalanced}`
-    )
-
-    // Step 3: Check if balanced (delta is empty) → complete
-    if (isBalanced) {
-      yield* Effect.logDebug("[BalanceV3] Transaction balanced!")
-      return { next: "complete" as Phase }
-    }
-
-    // Step 4: Not balanced - check for native assets in delta (shouldn't happen)
-    const hasNativeAssets = Object.keys(delta).some((key) => key !== "lovelace")
-    if (hasNativeAssets) {
-      return yield* Effect.fail(
-        new TransactionBuilderError({
-          message: `Balance verification failed: Delta contains native assets. This indicates a bug in change creation logic.`,
-          cause: { delta: formatAssetsForLog(delta) }
-        })
-      )
-    }
-
-    // Step 5: Handle imbalance (excess or shortfall)
-    const deltaLovelace = delta.lovelace
-
-    // Excess: inputs > outputs + change + fee
-    // This should NEVER happen with Option B design, EXCEPT:
-    // - Burn strategy: Positive delta is the burned leftover (expected and correct!)
-    // - ChangeCreation creates change = tentativeLeftover (when sufficient)
-    // - ChangeCreation routes to selection (when insufficient, never returns empty)
-    // - Balance should only see: delta = 0 (balanced) or delta < 0 (shortfall) or delta > 0 (burn mode)
-
-    if (deltaLovelace > 0n) {
-      // Check if this is expected from burn strategy
-      const isBurnMode = ctx.options?.onInsufficientChange === "burn" && buildCtx.changeOutputs.length === 0
-
-      // Check if this is expected from drainTo strategy
-      const isDrainToMode = ctx.options?.drainTo !== undefined && buildCtx.changeOutputs.length === 0
-
-      if (isDrainToMode) {
-        // DrainTo mode: Merge positive delta (leftover after fee) into target output
-        const drainToIndex = ctx.options.drainTo!
-        const outputs = yield* Ref.get(ctx.state.outputs)
-
-        // Validate drainTo index (should already be validated in Fallback, but double-check)
-        if (drainToIndex < 0 || drainToIndex >= outputs.length) {
-          return yield* Effect.fail(
-            new TransactionBuilderError({
-              message: `Invalid drainTo index: ${drainToIndex}. Must be between 0 and ${outputs.length - 1}`,
-              cause: { drainToIndex, outputCount: outputs.length }
-            })
-          )
-        }
-
-        // Merge delta into target output
-        const targetOutput = outputs[drainToIndex]
-        const newLovelace = targetOutput.assets.lovelace + deltaLovelace
-        const newAssets = { ...targetOutput.assets, lovelace: newLovelace }
-        const updatedOutput = { ...targetOutput, assets: newAssets }
-
-        // Update outputs
-        const newOutputs = [...outputs]
-        newOutputs[drainToIndex] = updatedOutput
-        yield* Ref.set(ctx.state.outputs, newOutputs)
-
-        // Recalculate totalOutputAssets
-        const newTotalOutputAssets = newOutputs.reduce((acc, output) => Assets.merge(acc, output.assets), {
-          lovelace: 0n
-        } as Assets.Assets)
-        yield* Ref.set(ctx.state.totalOutputAssets, newTotalOutputAssets)
-
-        yield* Effect.logDebug(
-          `[BalanceV3] DrainTo mode: Merged ${deltaLovelace} lovelace into output[${drainToIndex}]. ` +
-            `New output value: ${newLovelace}. Transaction balanced.`
-        )
-        return { next: "complete" as Phase }
-      } else if (isBurnMode) {
-        // Burn mode: Positive delta is the burned leftover (becomes implicit fee)
-        yield* Effect.logDebug(
-          `[BalanceV3] Burn mode: ${deltaLovelace} lovelace burned as implicit fee. ` + `Transaction balanced.`
-        )
-        return { next: "complete" as Phase }
-      } else {
-        // Not burn mode or drainTo: This is a bug
-        return yield* Effect.fail(
-          new TransactionBuilderError({
-            message:
-              ` CRITICAL BUG: Excess lovelace detected (${deltaLovelace}). ` +
-              `s Option B design should never produce positive delta. ` +
-              `This indicates incorrect change creation or fee calculation logic.`,
-            cause: {
-              delta: formatAssetsForLog(delta),
-              attempt: buildCtx.attempt,
-              calculatedFee: buildCtx.calculatedFee.toString(),
-              changeOutputs: buildCtx.changeOutputs.length,
-              totalInputs: formatAssetsForLog(inputAssets),
-              totalOutputs: formatAssetsForLog(outputAssets),
-              changeTotal: formatAssetsForLog(changeAssets)
-            }
-          })
-        )
-      }
-    }
-
-    // Shortfall: inputs < outputs + change + fee
-    // Return to changeCreation to recreate change with correct fee
-    // If leftover < minLovelace, changeCreation will trigger selection
-
-    yield* Effect.logDebug(
-      `[BalanceV3] Shortfall detected: ${-deltaLovelace} lovelace. ` +
-        `Returning to changeCreation to adjust change output.`
-    )
-
-    return { next: "changeCreation" as Phase }
-  })
-
-  // Handles insufficient change scenarios with drain or burn strategies.
-  // This phase is reached after MAX_ATTEMPTS exhausted in ChangeCreation.
-  // Only applies to ADA-only leftover (native assets cannot be drained/burned).
-  // Note: ChangeCreation ensures only ADA-only cases reach this phase.
-
-  const phaseFallbackV3 = Effect.gen(function* () {
-    yield* Effect.logDebug("Phase: Fallback")
-
-    const ctx = yield* TxContext
-    const buildCtxRef = yield* BuildContextTag
-    // Note: We don't merge the leftover here. Instead, we just clear change outputs
-    // and let the balance phase handle the merge after fee calculation.
-    // This avoids circular dependency: fee depends on outputs, but drain amount depends on fee.
-
-    // ---------------------------------------------------------------
-    // Strategy 1: drainTo - Merge leftover into existing output
-    // ---------------------------------------------------------------
-
-    if (ctx.options?.drainTo !== undefined) {
-      // Validate drainTo index
-      const outputs = yield* Ref.get(ctx.state.outputs)
-      const drainToIndex = ctx.options.drainTo
-
-      if (drainToIndex < 0 || drainToIndex >= outputs.length) {
-        return yield* Effect.fail(
-          new TransactionBuilderError({
-            message:
-              `Invalid drainTo index: ${drainToIndex}. ` +
-              `Transaction has ${outputs.length} output(s), valid indices are 0-${outputs.length - 1}.`,
-            cause: {
-              drainToIndex,
-              totalOutputs: outputs.length
-            }
-          })
-        )
-      }
-
-      // Clear change outputs - leftover will be merged in Balance phase
-      yield* Ref.update(buildCtxRef, (ctx) => ({
-        ...ctx,
-        changeOutputs: []
-      }))
-
-      yield* Effect.logDebug(
-        `[Fallback] DrainTo strategy: Change outputs cleared. ` +
-          `Leftover will be merged into output[${drainToIndex}] after fee calculation.`
-      )
-
-      // Go to fee calculation to recalculate without change outputs
-      return { next: "feeCalculation" as Phase }
-    }
-
-    // ---------------------------------------------------------------
-    // Strategy 2: burn - Allow leftover as implicit fee
-    // ---------------------------------------------------------------
-
-    if (ctx.options?.onInsufficientChange === "burn") {
-      // Clear change outputs (leftover becomes part of fee)
-      yield* Ref.update(buildCtxRef, (ctx) => ({
-        ...ctx,
-        changeOutputs: []
-      }))
-
-      yield* Effect.logDebug(
-        `[Fallback] Burn strategy: Leftover will be burned as implicit fee ` +
-          `(recalculating fee without change outputs).`
-      )
-
-      // Go to fee calculation to recalculate fee for transaction without change outputs
-      return { next: "feeCalculation" as Phase }
-    }
-
-    // ---------------------------------------------------------------
-    // Should never reach here
-    // ---------------------------------------------------------------
-    // ChangeCreation should only route to fallback if drainTo or burn is configured
-
-    return yield* Effect.fail(
-      new TransactionBuilderError({
-        message:
-          `[Fallback] CRITICAL BUG: Fallback phase reached without drainTo or burn configured. ` +
-          `ChangeCreation should have prevented this.`,
-        cause: {
-          hasDrainTo: ctx.options?.drainTo !== undefined,
-          hasOnInsufficientChange: ctx.options?.onInsufficientChange !== undefined
-        }
-      })
-    )
-  })
-
-  const buildEffectCoreV3 = (options?: BuildOptions) =>
-    Effect.gen(function* () {
-      const _ctx = yield* TxContext
-
-      // Resolve protocol parameters once at build start
-      // Priority: BuildOptions override > provider.Effect.getProtocolParameters() > error
-      const protocolParameters: ProtocolParameters = yield* options?.protocolParameters !== undefined
-        ? Effect.succeed(options.protocolParameters)
-        : _ctx.config.provider
-          ? Effect.map(
-              _ctx.config.provider.Effect.getProtocolParameters(),
-              (params): ProtocolParameters => ({
-                minFeeCoefficient: BigInt(params.minFeeA),
-                minFeeConstant: BigInt(params.minFeeB),
-                coinsPerUtxoByte: params.coinsPerUtxoByte,
-                maxTxSize: params.maxTxSize
-              })
-            )
-          : Effect.fail(
-              new TransactionBuilderError({
-                message:
-                  "No protocol parameters provided. Either provide protocolParameters in BuildOptions or provider in config.",
-                cause: null
-              })
-            )
-
-      // Resolve change address once at build start
-      // Priority: BuildOptions override > wallet.Effect.address() > error
-      const changeAddress: string = yield* options?.changeAddress
-        ? Effect.succeed(options.changeAddress)
-        : _ctx.config.wallet
-          ? _ctx.config.wallet.Effect.address()
-          : Effect.fail(
-              new TransactionBuilderError({
-                message:
-                  "No change address provided. Either provide wallet in config or changeAddress in build options.",
-                cause: null
-              })
-            )
-
-      // Resolve available UTxOs once at build start
-      // Priority: BuildOptions override > provider.Effect.getUtxos(wallet.address) > error
-      const availableUtxos: ReadonlyArray<UTxO.UTxO> = yield* options?.availableUtxos
-        ? Effect.succeed(options.availableUtxos)
-        : _ctx.config.wallet && _ctx.config.provider
-          ? Effect.flatMap(_ctx.config.wallet.Effect.address(), (addr) => _ctx.config.provider!.Effect.getUtxos(addr))
-          : Effect.fail(
-              new TransactionBuilderError({
-                message:
-                  "No available UTxOs provided. Either provide wallet+provider in config or availableUtxos in build options.",
-                cause: null
-              })
-            )
-
-      // No need to create resolvedConfig - we provide resolved values via context tags below
-
-      yield* Effect.all(programs, { concurrency: "unbounded" })
-
-      const initialBuildCtx: BuildContext = {
-        phase: "selection" as const,
-        attempt: 0,
-        calculatedFee: 0n,
-        shortfall: 0n,
-        changeOutputs: [],
-        leftoverAfterFee: { lovelace: 0n },
-        canUnfrack: options?.unfrack !== undefined
-      }
-
-      const ctxRef = yield* Ref.make(initialBuildCtx)
-
-      // Run phase loop and transaction assembly with all services provided
-      const { buildCtx, selectedUtxos, transaction, txWithFakeWitnesses } = yield* Effect.gen(function* () {
-        // Phase loop
-        while (true) {
-          const buildCtx = yield* Ref.get(ctxRef)
-
-          // Terminal state
-          if (buildCtx.phase === "complete") {
-            break
-          }
-
-          // Route to phase
-          let result: PhaseResult
-
-          switch (buildCtx.phase) {
-            case "selection": {
-              result = yield* phaseSelectionV3
-              break
-            }
-
-            case "changeCreation": {
-              result = yield* phaseChangeCreationV3
-              break
-            }
-
-            case "feeCalculation": {
-              result = yield* phaseFeeCalculationV3
-              break
-            }
-
-            case "balance": {
-              result = yield* phaseBalanceV3
-              break
-            }
-
-            case "fallback": {
-              result = yield* phaseFallbackV3
-              break
-            }
-
-            default:
-              return yield* Effect.fail(new TransactionBuilderError({ message: `Unknown phase: ${buildCtx.phase}` }))
-          }
-
-          // Update phase
-          yield* Ref.update(ctxRef, (c) => ({ ...c, phase: result.next }))
-        }
-
-        // 4. Add change outputs to transaction and assemble
-        const buildCtx = yield* Ref.get(ctxRef)
-        const ctx = yield* TxContext
-
-        yield* Effect.logDebug(`Build complete - fee: ${buildCtx.calculatedFee}`)
-
-        // Add change outputs to the transaction outputs
-        if (buildCtx.changeOutputs.length > 0) {
-          const currentOutputs = yield* Ref.get(ctx.state.outputs)
-          yield* Ref.set(ctx.state.outputs, [...currentOutputs, ...buildCtx.changeOutputs])
-
-          yield* Effect.logDebug(`Added ${buildCtx.changeOutputs.length} change output(s) to transaction`)
-        }
-
-        // Get final inputs and outputs for transaction assembly
-        const selectedUtxos = yield* Ref.get(ctx.state.selectedUtxos)
-        const allOutputs = yield* Ref.get(ctx.state.outputs)
-
-        yield* Effect.logDebug(
-          `Assembling transaction: ${selectedUtxos.length} inputs, ${allOutputs.length} outputs, fee: ${buildCtx.calculatedFee}`
-        )
-
-        // Build transaction inputs and assemble transaction body
-        const inputs = yield* buildTransactionInputs(selectedUtxos)
-        const transaction = yield* assembleTransaction(inputs, allOutputs, buildCtx.calculatedFee)
-
-        // SAFETY CHECK: Validate transaction size against protocol limit
-        const fakeWitnessSet = yield* buildFakeWitnessSet(selectedUtxos)
-
-        const txWithFakeWitnesses = new Transaction.Transaction({
-          body: transaction.body,
-          witnessSet: fakeWitnessSet,
-          isValid: true,
-          auxiliaryData: null
-        })
-
-        const txSizeWithWitnesses = yield* calculateTransactionSize(txWithFakeWitnesses)
-        const protocolParams = yield* ProtocolParametersTag
-
-        yield* Effect.logDebug(
-          `Transaction size: ${txSizeWithWitnesses} bytes ` +
-            `(with ${fakeWitnessSet.vkeyWitnesses?.length ?? 0} fake witnesses), ` +
-            `max=${protocolParams.maxTxSize} bytes`
-        )
-
-        if (txSizeWithWitnesses > protocolParams.maxTxSize) {
-          return yield* Effect.fail(
-            new TransactionBuilderError({
-              message:
-                `Transaction size (${txSizeWithWitnesses} bytes) exceeds protocol maximum (${protocolParams.maxTxSize} bytes). ` +
-                `Consider splitting into multiple transactions.`
-            })
-          )
-        }
-
-        // Return data for final result assembly
-        return {
-          transaction,
-          txWithFakeWitnesses,
-          buildCtx,
-          selectedUtxos
-        }
-      }).pipe(
-        Effect.provideService(BuildContextTag, ctxRef),
-        Effect.provideService(ProtocolParametersTag, protocolParameters),
-        Effect.provideService(ChangeAddressTag, changeAddress),
-        Effect.provideService(AvailableUtxosTag, availableUtxos)
-      )
-
-      // Assemble final result based on wallet capabilities
-      const ctx = yield* TxContext
-      const wallet = ctx.config.wallet
-
-      // Type guard: Check if wallet is signing-capable (has signTx method)
-      const isSigningWallet = wallet && "signTx" in wallet
-
-      if (isSigningWallet) {
-        // Return SignBuilder for signing-capable wallets
-        const signBuilder = makeSignBuilder({
-          transaction,
-          transactionWithFakeWitnesses: txWithFakeWitnesses,
-          fee: buildCtx.calculatedFee,
-          utxos: selectedUtxos,
-          provider: ctx.config.provider!,
-          wallet: wallet as WalletNew.SigningWallet | WalletNew.ApiWallet
-        })
-        return signBuilder
-      } else {
-        // Return TransactionResultBase for read-only wallets
-        const transactionResult = makeTransactionResult({
-          transaction,
-          transactionWithFakeWitnesses: txWithFakeWitnesses,
-          fee: buildCtx.calculatedFee
-        })
-        return transactionResult
-      }
-    }).pipe(
-      Effect.provideServiceEffect(
-        TxContext,
-        Effect.gen(function* () {
-          return {
-            config,
-            state: yield* createFreshState(),
-            options: options ?? {}
-          }
-        })
-      )
-    )
-
-  // Core Effect logic for chaining
-  const chainEffectCore = (options?: BuildOptions) =>
-    Effect.gen(function* () {
-      // Chain logic: Execute programs and return intermediate state
-      return {} as ChainResult
-    }).pipe(
-      Effect.provideServiceEffect(
-        TxContext,
-        Effect.gen(function* () {
-          return {
-            config,
-            state: yield* createFreshState(),
-            options: options ?? {}
-          }
-        })
-      ),
-      Effect.mapError(
-        (error) =>
-          new TransactionBuilderError({
-            message: "Chain failed",
-            cause: error
-          })
-      )
-    )
-
-  // Core Effect logic for partial build
-  const buildPartialEffectCore = (options?: BuildOptions) =>
-    Effect.gen(function* () {
-      // Execute all programs
-      yield* Effect.all(programs, { concurrency: "unbounded" })
-
-      // Return partial transaction (without evaluation)
-      return {} as Transaction.Transaction
-    }).pipe(
-      Effect.provideServiceEffect(
-        TxContext,
-        Effect.gen(function* () {
-          return {
-            config,
-            state: yield* createFreshState(),
-            options: options ?? {}
-          }
-        })
-      ),
-      Effect.mapError(
-        (error) =>
-          new TransactionBuilderError({
-            message: "Partial build failed",
-            cause: error
-          })
-      )
-    )
-
-  const txBuilder: TransactionBuilder<TResult> = {
+  const txBuilder = {
     // ============================================================================
     // Chainable builder methods - Create ProgramSteps, return same instance
     // ============================================================================
@@ -2058,48 +1421,42 @@ export const makeTxBuilder = <TResult = SignBuilder>(config: TxBuilderConfig): T
     // ============================================================================
 
     buildEffect: (options?: BuildOptions) => {
-      return buildEffectCoreV3(options) as unknown as Effect.Effect<
-        TResult,
-        TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError,
-        unknown
-      >
+      return buildEffectCore(config, programs, options)
     },
 
     build: (options?: BuildOptions) => {
-      return Effect.runPromise(
-        buildEffectCoreV3(options).pipe(
+      return runEffect(
+        buildEffectCore(config, programs, options).pipe(
           Effect.provide(Layer.merge(Logger.pretty, Logger.minimumLogLevel(LogLevel.Debug)))
         )
-      ) as unknown as Promise<TResult>
+      )
     },
     buildEither: (options?: BuildOptions) => {
-      return Effect.runPromise(
-        buildEffectCoreV3(options).pipe(
+      return runEffect(
+        buildEffectCore(config, programs, options).pipe(
           Effect.either,
           Effect.provide(Layer.merge(Logger.pretty, Logger.minimumLogLevel(LogLevel.Debug)))
         )
-      ) as unknown as Promise<
-        Either<TResult, TransactionBuilderError | EvaluationError | WalletNew.WalletError | Provider.ProviderError>
-      >
+      )
     },
 
     // ============================================================================
     // Transaction chaining methods
     // ============================================================================
 
-    chainEffect: (options?: BuildOptions) => chainEffectCore(options),
+    chainEffect: (options?: BuildOptions) => chainEffectCore(config, programs, options),
 
-    chain: (options?: BuildOptions) => Effect.runPromise(chainEffectCore(options)),
+    chain: (options?: BuildOptions) => runEffect(chainEffectCore(config, programs, options)),
 
-    chainEither: (options?: BuildOptions) => Effect.runPromise(chainEffectCore(options).pipe(Effect.either)),
+    chainEither: (options?: BuildOptions) => runEffect(chainEffectCore(config, programs, options).pipe(Effect.either)),
 
     // ============================================================================
     // Debug methods - Execute with fresh state, return partial transaction
     // ============================================================================
 
-    buildPartialEffect: (options?: BuildOptions) => buildPartialEffectCore(options),
+    buildPartialEffect: (options?: BuildOptions) => buildPartialEffectCore(config, programs, options),
 
-    buildPartial: (options?: BuildOptions) => Effect.runPromise(buildPartialEffectCore(options))
+    buildPartial: (options?: BuildOptions) => runEffect(buildPartialEffectCore(config, programs, options))
   }
 
   return txBuilder

--- a/packages/evolution/src/sdk/builders/TransactionResult.ts
+++ b/packages/evolution/src/sdk/builders/TransactionResult.ts
@@ -131,10 +131,6 @@ export interface TransactionResultBase {
  * Provides access to the unsigned transaction, fake-witness transaction for fee validation,
  * and fee estimation.
  * 
- * @param transaction - The unsigned transaction
- * @param transactionWithFakeWitnesses - The transaction with fake witnesses for size validation
- * @param fee - The calculated transaction fee in lovelace
- * 
  * @since 2.0.0
  * @category constructors
  */

--- a/packages/evolution/src/sdk/builders/index.ts
+++ b/packages/evolution/src/sdk/builders/index.ts
@@ -6,3 +6,8 @@ export * from "./SubmitBuilder.js"
 export * from "./SubmitBuilderImpl.js"
 export * from "./TransactionBuilder.js"
 export * from "./TransactionResult.js"
+
+// Internal modules for future refactoring (not yet exported to avoid duplication):
+// - BuildTypes.ts: Type definitions extracted from TransactionBuilder
+// - BuildContext.ts: Context definitions for transaction building
+// - BuildHelpers.ts: Helper functions (createUPLCEvaluator, etc.)

--- a/packages/evolution/src/sdk/builders/phases/Balance.ts
+++ b/packages/evolution/src/sdk/builders/phases/Balance.ts
@@ -1,0 +1,208 @@
+/**
+ * Balance Verification Phase
+ *
+ * Verifies that transaction inputs exactly equal outputs + change + fees.
+ * Handles three scenarios: balanced (complete), shortfall (retry), or excess (burn/drain).
+ *
+ * @module Balance
+ * @since 2.0.0
+ */
+
+import { Effect, Ref } from "effect"
+
+import * as Assets from "../../Assets.js"
+import { BuildOptionsTag, PhaseContextTag, TransactionBuilderError, TxContext } from "../TransactionBuilder.js"
+import type { PhaseResult } from "./Phases.js"
+
+/**
+ * Helper: Format assets for logging (BigInt-safe, truncates long unit names)
+ */
+const formatAssetsForLog = (assets: Assets.Assets): string => {
+  return Object.entries(assets)
+    .map(([unit, amount]) => `${unit.substring(0, 16)}...: ${amount.toString()}`)
+    .join(", ")
+}
+
+/**
+ * Balance Verification Phase
+ *
+ * Verifies that transaction inputs exactly equal outputs + change + fees.
+ * Handles three scenarios: balanced (complete), shortfall (retry), or excess (burn/drain).
+ *
+ * **Decision Flow:**
+ * ```
+ * Calculate Delta: inputs - outputs - change - fees
+ *   ↓
+ * Delta == 0?
+ *   ├─ YES → BALANCED: Complete transaction
+ *   └─ NO → Check delta value
+ *           ↓
+ *        Delta > 0 (Excess)?
+ *           ├─ YES → Check strategy
+ *           │         ├─ DrainTo mode? → Merge into target output → Complete
+ *           │         ├─ Burn mode? → Accept as implicit fee → Complete
+ *           │         └─ Neither? → ERROR (bug in change creation)
+ *           └─ NO (Delta < 0, Shortfall) → Return to changeCreation
+ * ```
+ *
+ * **Key Principles:**
+ * - Delta must equal exactly 0 (balanced) or negative (shortfall) in normal flow
+ * - Positive delta only occurs in burn/drainTo strategies (controlled scenarios)
+ * - Shortfall means change was underestimated; retry with adjusted fee
+ * - DrainTo merges excess into a specified output for exact balancing
+ * - Burn strategy treats excess as implicit fee (leftover becomes network fee)
+ * - Native assets in delta indicate a bug (should never happen with proper change creation)
+ * - This is the final verification gate before transaction completion
+ */
+export const executeBalance = (): Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | BuildOptionsTag
+> =>
+  Effect.gen(function* () {
+    // Step 1: Get contexts and log start
+    const ctx = yield* TxContext
+    const buildCtxRef = yield* PhaseContextTag
+    const buildCtx = yield* Ref.get(buildCtxRef)
+
+    yield* Effect.logDebug(`[Balance] Starting balance verification (attempt ${buildCtx.attempt})`)
+
+    // Step 2: Calculate delta = inputs - outputs - change - fee
+    const state = yield* Ref.get(ctx)
+    const inputAssets = state.totalInputAssets
+    const outputAssets = state.totalOutputAssets
+
+    // Calculate total change assets
+    const changeAssets = buildCtx.changeOutputs.reduce(
+      (acc, output) => Assets.merge(acc, output.assets),
+      { lovelace: 0n } as Assets.Assets
+    )
+
+    // Delta = inputs - outputs - change - fee
+    let delta = Assets.subtract(inputAssets, outputAssets)
+    delta = Assets.subtract(delta, changeAssets)
+    delta = { ...delta, lovelace: delta.lovelace - buildCtx.calculatedFee }
+
+    // Check if balanced: lovelace must be exactly 0 and all native assets must be 0
+    const isBalanced = delta.lovelace === 0n
+
+    yield* Effect.logDebug(
+      `[Balance] Inputs: ${formatAssetsForLog(inputAssets)}, ` +
+        `Outputs: ${formatAssetsForLog(outputAssets)}, ` +
+        `Change: ${formatAssetsForLog(changeAssets)}, ` +
+        `Fee: ${buildCtx.calculatedFee}, ` +
+        `Delta: ${formatAssetsForLog(delta)}, ` +
+        `Balanced: ${isBalanced}`
+    )
+
+    // Step 3: Check if balanced (delta is empty) → complete
+    if (isBalanced) {
+      yield* Effect.logDebug("[Balance] Transaction balanced!")
+      return { next: "complete" as const }
+    }
+
+    // Step 4: Not balanced - check for native assets in delta (shouldn't happen)
+    const hasNativeAssets = Object.keys(delta).some((key) => key !== "lovelace")
+    if (hasNativeAssets) {
+      return yield* Effect.fail(
+        new TransactionBuilderError({
+          message: `Balance verification failed: Delta contains native assets. This indicates a bug in change creation logic.`,
+          cause: { delta: formatAssetsForLog(delta) }
+        })
+      )
+    }
+
+    // Step 5: Handle imbalance (excess or shortfall)
+    const deltaLovelace = delta.lovelace
+
+    // Excess: inputs > outputs + change + fee
+    if (deltaLovelace > 0n) {
+      // Check if this is expected from burn strategy
+      const buildOptions = yield* BuildOptionsTag
+      const isBurnMode = buildOptions.onInsufficientChange === "burn" && buildCtx.changeOutputs.length === 0
+
+      // Check if this is expected from drainTo strategy
+      const isDrainToMode = buildOptions.drainTo !== undefined && buildCtx.changeOutputs.length === 0
+
+      if (isDrainToMode) {
+        // DrainTo mode: Merge positive delta (leftover after fee) into target output
+        const drainToIndex = buildOptions.drainTo!
+        const state = yield* Ref.get(ctx)
+        const outputs = state.outputs
+
+        // Validate drainTo index (should already be validated in Fallback, but double-check)
+        if (drainToIndex < 0 || drainToIndex >= outputs.length) {
+          return yield* Effect.fail(
+            new TransactionBuilderError({
+              message: `Invalid drainTo index: ${drainToIndex}. Must be between 0 and ${outputs.length - 1}`,
+              cause: { drainToIndex, outputCount: outputs.length }
+            })
+          )
+        }
+
+        // Merge delta into target output
+        const targetOutput = outputs[drainToIndex]
+        const newLovelace = targetOutput.assets.lovelace + deltaLovelace
+        const newAssets = { ...targetOutput.assets, lovelace: newLovelace }
+        const updatedOutput = { ...targetOutput, assets: newAssets }
+
+        // Update outputs
+        const newOutputs = [...outputs]
+        newOutputs[drainToIndex] = updatedOutput
+
+        // Recalculate totalOutputAssets
+        const newTotalOutputAssets = newOutputs.reduce(
+          (acc, output) => Assets.merge(acc, output.assets),
+          { lovelace: 0n } as Assets.Assets
+        )
+
+        yield* Ref.update(ctx, (s) => ({
+          ...s,
+          outputs: newOutputs,
+          totalOutputAssets: newTotalOutputAssets
+        }))
+
+        yield* Effect.logDebug(
+          `[Balance] DrainTo mode: Merged ${deltaLovelace} lovelace into output[${drainToIndex}]. ` +
+            `New output value: ${newLovelace}. Transaction balanced.`
+        )
+        return { next: "complete" as const }
+      } else if (isBurnMode) {
+        // Burn mode: Positive delta is the burned leftover (becomes implicit fee)
+        yield* Effect.logDebug(
+          `[Balance] Burn mode: ${deltaLovelace} lovelace burned as implicit fee. ` + `Transaction balanced.`
+        )
+        return { next: "complete" as const }
+      } else {
+        // Not burn mode or drainTo: This is a bug
+        return yield* Effect.fail(
+          new TransactionBuilderError({
+            message:
+              ` CRITICAL BUG: Excess lovelace detected (${deltaLovelace}). ` +
+              `Option B design should never produce positive delta. ` +
+              `This indicates incorrect change creation or fee calculation logic.`,
+            cause: {
+              delta: formatAssetsForLog(delta),
+              attempt: buildCtx.attempt,
+              calculatedFee: buildCtx.calculatedFee.toString(),
+              changeOutputs: buildCtx.changeOutputs.length,
+              totalInputs: formatAssetsForLog(inputAssets),
+              totalOutputs: formatAssetsForLog(outputAssets),
+              changeTotal: formatAssetsForLog(changeAssets)
+            }
+          })
+        )
+      }
+    }
+
+    // Shortfall: inputs < outputs + change + fee
+    // Return to changeCreation to recreate change with correct fee
+    // If leftover < minLovelace, changeCreation will trigger selection
+
+    yield* Effect.logDebug(
+      `[Balance] Shortfall detected: ${-deltaLovelace} lovelace. ` +
+        `Returning to changeCreation to adjust change output.`
+    )
+
+    return { next: "changeCreation" as const }
+  })

--- a/packages/evolution/src/sdk/builders/phases/ChangeCreation.ts
+++ b/packages/evolution/src/sdk/builders/phases/ChangeCreation.ts
@@ -1,0 +1,315 @@
+/**
+ * Change Creation Phase - Change Output Generation
+ *
+ * Creates change outputs from leftover assets using a cascading retry strategy.
+ * Handles both unfrack (N outputs) and single output approaches with fallback options.
+ *
+ * @module ChangeCreation
+ * @since 2.0.0
+ */
+
+import { Effect, Ref } from "effect"
+
+import * as Assets from "../../Assets.js"
+import type * as UTxO from "../../UTxO.js"
+import {
+  AvailableUtxosTag,
+  BuildOptionsTag,
+  ChangeAddressTag,
+  PhaseContextTag,
+  ProtocolParametersTag,
+  TransactionBuilderError,
+  TxContext
+} from "../TransactionBuilder.js"
+import { calculateMinimumUtxoLovelace } from "../TxBuilderImpl.js"
+import * as Unfrack from "../Unfrack.js"
+import type { PhaseResult } from "./Phases.js"
+
+/**
+ * Helper: Format assets for logging (BigInt-safe, truncates long unit names)
+ */
+const formatAssetsForLog = (assets: Assets.Assets): string => {
+  return Object.entries(assets)
+    .map(([unit, amount]) => `${unit.substring(0, 16)}...: ${amount.toString()}`)
+    .join(", ")
+}
+
+/**
+ * Get UTxOs that haven't been selected yet.
+ * Uses Set for O(1) lookup instead of O(n) for better performance.
+ */
+const getAvailableUtxos = (
+  allUtxos: ReadonlyArray<UTxO.UTxO>,
+  selectedUtxos: ReadonlyArray<UTxO.UTxO>
+): ReadonlyArray<UTxO.UTxO> => {
+  const selectedKeys = new Set(selectedUtxos.map((u) => `${u.txHash}:${u.outputIndex}`))
+  return allUtxos.filter((utxo) => !selectedKeys.has(`${utxo.txHash}:${utxo.outputIndex}`))
+}
+
+/**
+ * Helper: Create unfracked change outputs (multiple outputs)
+ * Only called when unfrack option is enabled.
+ * Returns change outputs array or empty array if unfrack is not viable.
+ */
+const createChangeOutputs = (
+  leftoverAfterFee: Assets.Assets,
+  changeAddress: string,
+  coinsPerUtxoByte: bigint
+): Effect.Effect<ReadonlyArray<UTxO.TxOutput>, TransactionBuilderError, BuildOptionsTag> =>
+  Effect.gen(function* () {
+    // Empty leftover = no change needed
+    if (Assets.isEmpty(leftoverAfterFee)) {
+      return []
+    }
+
+    // Create unfracked outputs with proper minUTxO calculation
+    const buildOptions = yield* BuildOptionsTag
+    const unfrackOptions = buildOptions.unfrack! // Safe: only called when unfrack is enabled
+
+    const changeOutputs = yield* Unfrack.createUnfrackedChangeOutputs(
+      changeAddress,
+      leftoverAfterFee,
+      unfrackOptions,
+      coinsPerUtxoByte
+    ).pipe(
+      Effect.mapError(
+        (err) =>
+          new TransactionBuilderError({
+            message: `Failed to create unfracked change outputs: ${err.message}`,
+            cause: err
+          })
+      )
+    )
+
+    yield* Effect.logDebug(`[ChangeCreation] Created ${changeOutputs.length} unfracked change outputs`)
+
+    return changeOutputs
+  })
+
+/**
+ * Change Creation Phase
+ *
+ * Creates change outputs from leftover assets using a cascading retry strategy.
+ * Both unfrack (N outputs) and single output follow the same retry pattern:
+ * try with available funds → if insufficient, reselect (up to MAX_ATTEMPTS) → fallback.
+ *
+ * **Symmetric Retry Flow (Unfrack vs Single Output):**
+ * ```
+ * UNFRACK (N outputs)                    SINGLE OUTPUT (1 output)
+ * ─────────────────────────────────────────────────────────────────
+ *
+ * Try: Create N outputs                  Try: Create 1 output
+ * ↓                                      ↓
+ * Check: leftover >= (minUTxO × N)?      Check: leftover >= minUTxO?
+ * ↓                                      ↓
+ * If NO (not affordable):                If NO (insufficient):
+ *   ├─ attempt < MAX? → Reselect           ├─ attempt < MAX? → Reselect
+ *   └─ attempt >= MAX? → Fallback          └─ attempt >= MAX? → Fallback
+ *                                                               ↓
+ * Fallback:                              Fallback:
+ *   └─ Single output                       ├─ drainTo (merge into output)
+ *       ├─ (retry/fallback)                ├─ burn (leftover → fee)
+ *       └─ ...                             └─ error
+ * ```
+ *
+ * **Detailed Flow:**
+ * ```
+ * 1. Calculate tentative leftover (inputs - outputs - contextFee)
+ *
+ * 2. If unfrack enabled and canUnfrack=true:
+ *    → Try createUnfrackedChangeOutputs() (N outputs)
+ *    → Success: store N outputs, goto FeeCalculation
+ *    → Not affordable:
+ *       ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
+ *       └─ If attempt >= MAX_ATTEMPTS: canUnfrack=false, goto step 3
+ *
+ * 3. Single output approach:
+ *    → Create 1 change output with leftover
+ *    → Success: store 1 output, goto FeeCalculation
+ *    → Not affordable:
+ *       ├─ If attempt < MAX_ATTEMPTS: reselect (add more UTxOs)
+ *       └─ If attempt >= MAX_ATTEMPTS: goto step 4
+ *
+ * 4. Insufficient change fallbacks (single-output only):
+ *    a. If drainTo specified: merge into existing output
+ *    b. If onInsufficientChange="burn": leftover becomes fee
+ *    c. If onInsufficientChange="error": throw error
+ * ```
+ *
+ * **Key Principles:**
+ * - Unfrack and single output use SAME retry mechanism (reselection up to MAX_ATTEMPTS)
+ * - Phase loop handles fee convergence (leftover recalculated each iteration)
+ * - Last subdivision output absorbs remainder for exact balance
+ * - canUnfrack flag prevents retry loops (once false, stays false)
+ * - drainTo and burn are terminal fallbacks (single-output only)
+ * - Unfrack outputs bypass drainTo/burn (they're already valid)
+ */
+export const executeChangeCreation = (): Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | ChangeAddressTag | BuildOptionsTag | ProtocolParametersTag | AvailableUtxosTag
+> =>
+  Effect.gen(function* () {
+    const stateRef = yield* TxContext
+    const buildCtxRef = yield* PhaseContextTag
+    const buildCtx = yield* Ref.get(buildCtxRef)
+    const changeAddress = yield* ChangeAddressTag
+    const buildOptions = yield* BuildOptionsTag
+
+    yield* Effect.logDebug(`[ChangeCreation] Fee from context: ${buildCtx.calculatedFee}`)
+
+    // Step 2: Calculate leftover assets
+    const state = yield* Ref.get(stateRef)
+    const inputAssets = state.totalInputAssets
+    const outputAssets = state.totalOutputAssets
+    const leftoverBeforeFee = Assets.subtract(inputAssets, outputAssets)
+
+    const tentativeLeftover: Assets.Assets = {
+      ...leftoverBeforeFee,
+      lovelace: leftoverBeforeFee.lovelace - buildCtx.calculatedFee
+    }
+
+    // Step 3: Check if negative - return to selection immediately
+    if (tentativeLeftover.lovelace < 0n) {
+      const shortfall = -tentativeLeftover.lovelace
+
+      yield* Effect.logDebug(
+        `[ChangeCreation] Insufficient lovelace for fee: ${tentativeLeftover.lovelace}. ` +
+          `Shortfall: ${shortfall}. Returning to selection.`
+      )
+
+      yield* Ref.update(buildCtxRef, (ctx) => ({
+        ...ctx,
+        shortfall,
+        changeOutputs: []
+      }))
+      return { next: "selection" as const }
+    }
+
+    // Step 4: Affordability check - verify minimum (single output) is affordable
+    const protocolParams = yield* ProtocolParametersTag
+    const minLovelaceForSingle = yield* calculateMinimumUtxoLovelace({
+      address: changeAddress,
+      assets: tentativeLeftover,
+      coinsPerUtxoByte: protocolParams.coinsPerUtxoByte
+    })
+
+    if (tentativeLeftover.lovelace < minLovelaceForSingle) {
+      // Not even affordable for single output - trigger reselection
+      const shortfall = minLovelaceForSingle - tentativeLeftover.lovelace
+      const buildCtx = yield* Ref.get(buildCtxRef)
+      const MAX_ATTEMPTS = 3
+
+      // Check if leftover is ADA-only (no native assets)
+      const isAdaOnlyLeftover = Object.keys(tentativeLeftover).length === 1 // Only "lovelace" key
+
+      // Check if we have available UTxOs for reselection
+      const state = yield* Ref.get(stateRef)
+      const alreadySelected = state.selectedUtxos
+      const allAvailableUtxos = yield* AvailableUtxosTag
+      const availableUtxos = getAvailableUtxos(allAvailableUtxos, alreadySelected)
+      const hasMoreUtxos = availableUtxos.length > 0
+
+      // Try reselection up to MAX_ATTEMPTS (if UTxOs available)
+      if (hasMoreUtxos && buildCtx.attempt < MAX_ATTEMPTS) {
+        yield* Effect.logDebug(
+          `[ChangeCreation] Leftover ${tentativeLeftover.lovelace} < ${minLovelaceForSingle} minUTxO ` +
+            `(shortfall: ${shortfall}${isAdaOnlyLeftover ? ", ADA-only" : ", with native assets"}). ` +
+            `Attempting reselection (${buildCtx.attempt + 1}/${MAX_ATTEMPTS})`
+        )
+
+        yield* Ref.update(buildCtxRef, (ctx) => ({
+          ...ctx,
+          shortfall,
+          changeOutputs: []
+        }))
+
+        return { next: "selection" as const }
+      }
+
+      // No more UTxOs OR MAX_ATTEMPTS exhausted - check fallback options
+      yield* Effect.logDebug(
+        `[ChangeCreation] Cannot reselect: ${!hasMoreUtxos ? "No more UTxOs available" : `MAX_ATTEMPTS (${MAX_ATTEMPTS}) exhausted`}. ` +
+          `Leftover (before fee): ${formatAssetsForLog(tentativeLeftover)}, minUTxO: ${minLovelaceForSingle}`
+      )
+
+      // CASE 1: Native assets present - cannot use drain/burn fallback
+      if (!isAdaOnlyLeftover) {
+        return yield* Effect.fail(
+          new TransactionBuilderError({
+            message:
+              `Cannot balance transaction: Native assets present in leftover ` +
+              `but insufficient lovelace (${tentativeLeftover.lovelace} < ${minLovelaceForSingle} minUTxO) ` +
+              `after ${buildCtx.attempt} selection attempts.\n\n` +
+              `Your leftover includes native assets (tokens) which require at least ` +
+              `${minLovelaceForSingle} lovelace to create a valid change output, but only ` +
+              `${tentativeLeftover.lovelace} lovelace remains.\n\n` +
+              `Solutions:\n` +
+              `1. Include the native assets in your payment outputs\n` +
+              `2. Add more lovelace to your wallet\n` +
+              `3. Use fewer/smaller outputs to reduce fees`,
+            cause: undefined
+          })
+        )
+      }
+
+      // CASE 2: ADA-only leftover - check if fallback strategies are configured
+      const hasFallbackStrategy =
+        buildOptions.drainTo !== undefined || buildOptions.onInsufficientChange === "burn"
+
+      if (!hasFallbackStrategy) {
+        // No fallback configured - fail with clear user-facing error
+        return yield* Effect.fail(
+          new TransactionBuilderError({
+            message:
+              `Cannot create valid change: Insufficient funds to cover payment, fees, and minimum UTxO requirements.\n\n` +
+              `Available: ${tentativeLeftover.lovelace} lovelace\n` +
+              `Required: At least ${minLovelaceForSingle} lovelace for change output\n\n` +
+              `Solutions:\n` +
+              `1. Add more funds to your wallet\n` +
+              `2. Reduce payment amounts or number of outputs\n` +
+              `3. Use drainTo(index) to merge leftover with an existing output\n` +
+              `4. Use onInsufficientChange: 'burn' to explicitly burn leftover as extra fee`,
+            cause: undefined
+          })
+        )
+      }
+
+      // Fallback strategies configured - proceed to Fallback phase
+      return { next: "fallback" as const }
+    }
+
+    // Step 5: Unfrack path (single output IS affordable, try bundles/subdivision)
+    if (buildOptions.unfrack && buildCtx.canUnfrack) {
+      const protocolParams = yield* ProtocolParametersTag
+      const changeOutputs = yield* createChangeOutputs(
+        tentativeLeftover,
+        changeAddress,
+        protocolParams.coinsPerUtxoByte
+      )
+
+      yield* Effect.logDebug(`[ChangeCreation] Successfully created ${changeOutputs.length} unfracked outputs`)
+
+      // Store outputs and proceed to fee calculation
+      yield* Ref.update(buildCtxRef, (ctx) => ({
+        ...ctx,
+        changeOutputs
+      }))
+      return { next: "feeCalculation" as const }
+    }
+
+    // Step 6: Single output path - create single change output
+    const singleOutput: UTxO.TxOutput = {
+      address: changeAddress,
+      assets: tentativeLeftover,
+      datumOption: undefined,
+      scriptRef: undefined
+    }
+
+    yield* Ref.update(buildCtxRef, (ctx) => ({
+      ...ctx,
+      changeOutputs: [singleOutput]
+    }))
+
+    return { next: "feeCalculation" as const }
+  })

--- a/packages/evolution/src/sdk/builders/phases/Fallback.ts
+++ b/packages/evolution/src/sdk/builders/phases/Fallback.ts
@@ -1,0 +1,143 @@
+/**
+ * Fallback Phase - Terminal Strategy Selection
+ *
+ * Handles insufficient change scenarios after MAX_ATTEMPTS exhausted in ChangeCreation.
+ * Routes to one of two terminal strategies: drainTo (merge leftover) or burn (implicit fee).
+ *
+ * @module Fallback
+ * @since 2.0.0
+ */
+
+import { Effect, Ref } from "effect"
+
+import { BuildOptionsTag, PhaseContextTag, TransactionBuilderError, TxContext } from "../TransactionBuilder.js"
+import type { PhaseResult } from "./Phases.js"
+
+/**
+ * Fallback Phase - Terminal Strategy Selection
+ *
+ * Handles insufficient change scenarios after MAX_ATTEMPTS exhausted in ChangeCreation.
+ * Routes to one of two terminal strategies: drainTo (merge leftover) or burn (implicit fee).
+ * This phase is only reached when change creation cannot create a valid change output
+ * and a fallback strategy is configured.
+ *
+ * **Decision Flow:**
+ * ```
+ * Fallback Phase Triggered
+ * (MAX_ATTEMPTS exhausted in changeCreation)
+ *   ↓
+ * Check: drainTo configured?
+ *   ├─ YES → Validate drainTo index
+ *   │         ├─ Valid → Clear change outputs
+ *   │         │          Return to feeCalculation
+ *   │         │          (leftover merged in balance phase)
+ *   │         └─ Invalid → ERROR (invalid output index)
+ *   └─ NO → Check: burn strategy?
+ *           ├─ YES → Clear change outputs
+ *           │        Return to feeCalculation
+ *           │        (leftover becomes implicit fee)
+ *           └─ NO → ERROR (no strategy configured)
+ *                   (ChangeCreation should prevent this)
+ * ```
+ *
+ * **Key Principles:**
+ * - Fallback only handles ADA-only leftover (ChangeCreation filters native asset cases)
+ * - DrainTo merges excess into a specified output, deferring actual merge to Balance phase
+ * - Burn strategy accepts leftover as implicit network fee
+ * - Both strategies clear change outputs and recalculate fee (leftover not in outputs)
+ * - Invalid drainTo index is caught here with validation
+ * - Reaching fallback without a strategy configured indicates a bug in ChangeCreation routing
+ * - Fee recalculation after clearing change ensures accurate final fee
+ */
+export const executeFallback = (): Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | BuildOptionsTag
+> =>
+  Effect.gen(function* () {
+    yield* Effect.logDebug("Phase: Fallback")
+
+    const ctx = yield* TxContext
+    const buildCtxRef = yield* PhaseContextTag
+    // Note: We don't merge the leftover here. Instead, we just clear change outputs
+    // and let the balance phase handle the merge after fee calculation.
+    // This avoids circular dependency: fee depends on outputs, but drain amount depends on fee.
+
+    // ---------------------------------------------------------------
+    // Strategy 1: drainTo - Merge leftover into existing output
+    // ---------------------------------------------------------------
+
+    const buildOptions = yield* BuildOptionsTag
+
+    if (buildOptions.drainTo !== undefined) {
+      // Validate drainTo index
+      const state = yield* Ref.get(ctx)
+      const outputs = state.outputs
+      const drainToIndex = buildOptions.drainTo
+
+      if (drainToIndex < 0 || drainToIndex >= outputs.length) {
+        return yield* Effect.fail(
+          new TransactionBuilderError({
+            message:
+              `Invalid drainTo index: ${drainToIndex}. ` +
+              `Transaction has ${outputs.length} output(s), valid indices are 0-${outputs.length - 1}.`,
+            cause: {
+              drainToIndex,
+              totalOutputs: outputs.length
+            }
+          })
+        )
+      }
+
+      // Clear change outputs - leftover will be merged in Balance phase
+      yield* Ref.update(buildCtxRef, (ctx) => ({
+        ...ctx,
+        changeOutputs: []
+      }))
+
+      yield* Effect.logDebug(
+        `[Fallback] DrainTo strategy: Change outputs cleared. ` +
+          `Leftover will be merged into output[${drainToIndex}] after fee calculation.`
+      )
+
+      // Go to fee calculation to recalculate without change outputs
+      return { next: "feeCalculation" as const }
+    }
+
+    // ---------------------------------------------------------------
+    // Strategy 2: burn - Allow leftover as implicit fee
+    // ---------------------------------------------------------------
+
+    if (buildOptions.onInsufficientChange === "burn") {
+      // Clear change outputs (leftover becomes part of fee)
+      yield* Ref.update(buildCtxRef, (ctx) => ({
+        ...ctx,
+        changeOutputs: []
+      }))
+
+      yield* Effect.logDebug(
+        `[Fallback] Burn strategy: Leftover will be burned as implicit fee ` +
+          `(recalculating fee without change outputs).`
+      )
+
+      // Go to fee calculation to recalculate fee for transaction without change outputs
+      return { next: "feeCalculation" as const }
+    }
+
+    // ---------------------------------------------------------------
+    // Should never reach here
+    // ---------------------------------------------------------------
+    // ChangeCreation should only route to fallback if drainTo or burn is configured
+
+    return yield* Effect.fail(
+      new TransactionBuilderError({
+        message:
+          `[Fallback] CRITICAL BUG: Fallback phase reached without drainTo or burn configured. ` +
+          `ChangeCreation should have prevented this.`,
+        cause: {
+          hasDrainTo: buildOptions.drainTo !== undefined,
+          hasOnInsufficientChange: buildOptions.onInsufficientChange !== undefined
+        }
+      })
+    )
+  })

--- a/packages/evolution/src/sdk/builders/phases/FeeCalculation.ts
+++ b/packages/evolution/src/sdk/builders/phases/FeeCalculation.ts
@@ -1,0 +1,107 @@
+/**
+ * Fee Calculation Phase
+ *
+ * Calculates transaction fee based on current inputs and outputs (including change).
+ * Stores both calculated fee and leftover amount for the Balance phase to verify.
+ *
+ * @module FeeCalculation
+ * @since 2.0.0
+ */
+
+import { Effect, Ref } from "effect"
+
+import * as Assets from "../../Assets.js"
+import type { TransactionBuilderError } from "../TransactionBuilder.js"
+import { PhaseContextTag, ProtocolParametersTag, TxContext } from "../TransactionBuilder.js"
+import { buildTransactionInputs, calculateFeeIteratively } from "../TxBuilderImpl.js"
+import type { PhaseResult } from "./Phases.js"
+
+/**
+ * Fee Calculation Phase
+ *
+ * Calculates transaction fee based on current inputs and outputs (including change).
+ * Stores both calculated fee and leftover amount for the Balance phase to verify.
+ * This phase is deterministic once inputs and outputs are fixed.
+ *
+ * **Decision Flow:**
+ * ```
+ * Combine Inputs & Outputs
+ * (base outputs + change outputs)
+ *   ↓
+ * Calculate Fee Iteratively
+ * (account for changing tx size during fee calculation)
+ *   ↓
+ * Calculate Leftover After Fee
+ * (inputs - outputs - change - fee)
+ *   ↓
+ * Store Fee & Leftover
+ * (in build context for Balance phase)
+ *   ↓
+ * goto balance
+ * ```
+ *
+ * **Key Principles:**
+ * - Fee calculation is deterministic given fixed inputs/outputs/change
+ * - Iterative calculation accounts for fee size affecting tx size
+ * - Leftover = inputs - outputs - change - fee (can be 0, positive, or negative)
+ * - Positive leftover triggers Balance → drainTo/burn strategies
+ * - Negative leftover (shortfall) triggers Balance → reselection
+ * - Zero leftover means perfectly balanced (ideal case)
+ * - Change outputs are always included in fee calculation
+ * - Fee is stored in context for Balance phase validation
+ * - No phase retries here; Balance phase decides next step based on leftover
+ */
+export const executeFeeCalculation = (): Effect.Effect<
+  PhaseResult,
+  TransactionBuilderError,
+  PhaseContextTag | TxContext | ProtocolParametersTag
+> =>
+  Effect.gen(function* () {
+    // Step 1: Get contexts and current state
+    const ctx = yield* TxContext
+    const buildCtxRef = yield* PhaseContextTag
+    const buildCtx = yield* Ref.get(buildCtxRef)
+
+    const state = yield* Ref.get(ctx)
+    const selectedUtxos = state.selectedUtxos
+    const baseOutputs = state.outputs
+
+    // Step 2: Build transaction inputs
+    const inputs = yield* buildTransactionInputs(selectedUtxos)
+
+    // Step 3: Combine base outputs + change outputs
+    yield* Effect.logDebug(
+      `[FeeCalculation] Starting fee calculation with ${baseOutputs.length} base outputs + ${buildCtx.changeOutputs.length} change outputs`
+    )
+
+    const allOutputs = [...baseOutputs, ...buildCtx.changeOutputs]
+
+    // Step 4: Calculate fee WITH change outputs
+    const protocolParams = yield* ProtocolParametersTag
+    const calculatedFee = yield* calculateFeeIteratively(selectedUtxos, inputs, allOutputs, {
+      minFeeCoefficient: protocolParams.minFeeCoefficient,
+      minFeeConstant: protocolParams.minFeeConstant
+    })
+
+    yield* Effect.logDebug(`[FeeCalculation] Calculated fee: ${calculatedFee}`)
+
+    // Step 5: Calculate leftover after fee NOW (after fee is known)
+    const state2 = yield* Ref.get(ctx)
+    const inputAssets = state2.totalInputAssets
+    const outputAssets = state2.totalOutputAssets
+    const leftoverBeforeFee = Assets.subtract(inputAssets, outputAssets)
+
+    const leftoverAfterFee: Assets.Assets = {
+      ...leftoverBeforeFee,
+      lovelace: leftoverBeforeFee.lovelace - calculatedFee
+    }
+
+    // Step 6: Store both fee and leftoverAfterFee in context
+    yield* Ref.update(buildCtxRef, (ctx) => ({
+      ...ctx,
+      calculatedFee,
+      leftoverAfterFee
+    }))
+
+    return { next: "balance" as const }
+  })

--- a/packages/evolution/src/sdk/builders/phases/Phases.ts
+++ b/packages/evolution/src/sdk/builders/phases/Phases.ts
@@ -1,0 +1,25 @@
+/**
+ * Core type definitions for transaction builder phases.
+ *
+ * Each phase is modularized into its own file and executes as part
+ * of the transaction state machine.
+ *
+ * @module Phases
+ * @since 2.0.0
+ */
+
+/**
+ * Build phases of the transaction state machine.
+ *
+ * @since 2.0.0
+ */
+export type Phase = "selection" | "changeCreation" | "feeCalculation" | "balance" | "fallback" | "complete"
+
+/**
+ * Result returned by a phase indicating the next phase to execute.
+ *
+ * @since 2.0.0
+ */
+export interface PhaseResult {
+  readonly next: Phase
+}

--- a/packages/evolution/src/sdk/builders/phases/Selection.ts
+++ b/packages/evolution/src/sdk/builders/phases/Selection.ts
@@ -1,0 +1,241 @@
+/**
+ * Selection Phase - UTxO Coin Selection
+ *
+ * Selects UTxOs from available pool to cover transaction outputs, fees, and change requirements.
+ * Handles both initial selection and reselection with retry logic up to MAX_ATTEMPTS.
+ *
+ * @module Selection
+ * @since 2.0.0
+ */
+
+import { Effect, Ref } from "effect"
+
+import * as Assets from "../../Assets.js"
+import type * as UTxO from "../../UTxO.js"
+import type { CoinSelectionAlgorithm, CoinSelectionFunction } from "../CoinSelection.js"
+import { largestFirstSelection } from "../CoinSelection.js"
+import {
+  AvailableUtxosTag,
+  BuildOptionsTag,
+  PhaseContextTag,
+  TransactionBuilderError,
+  TxContext
+} from "../TransactionBuilder.js"
+import { calculateTotalAssets } from "../TxBuilderImpl.js"
+import type { PhaseResult } from "./Phases.js"
+
+/**
+ * Helper: Format assets for logging (BigInt-safe, truncates long unit names)
+ */
+const formatAssetsForLog = (assets: Assets.Assets): string => {
+  return Object.entries(assets)
+    .map(([unit, amount]) => `${unit.substring(0, 16)}...: ${amount.toString()}`)
+    .join(", ")
+}
+
+/**
+ * Get UTxOs that haven't been selected yet.
+ * Uses Set for O(1) lookup instead of O(n) for better performance.
+ */
+const getAvailableUtxos = (
+  allUtxos: ReadonlyArray<UTxO.UTxO>,
+  selectedUtxos: ReadonlyArray<UTxO.UTxO>
+): ReadonlyArray<UTxO.UTxO> => {
+  const selectedKeys = new Set(selectedUtxos.map((u) => `${u.txHash}:${u.outputIndex}`))
+  return allUtxos.filter((utxo) => !selectedKeys.has(`${utxo.txHash}:${utxo.outputIndex}`))
+}
+
+/**
+ * Helper: Get coin selection algorithm function from name
+ */
+const getCoinSelectionAlgorithm = (algorithm: CoinSelectionAlgorithm): CoinSelectionFunction => {
+  switch (algorithm) {
+    case "largest-first":
+      return largestFirstSelection
+    case "random-improve":
+      throw new TransactionBuilderError({
+        message: "random-improve algorithm not yet implemented",
+        cause: { algorithm }
+      })
+    case "optimal":
+      throw new TransactionBuilderError({
+        message: "optimal algorithm not yet implemented",
+        cause: { algorithm }
+      })
+    default:
+      throw new TransactionBuilderError({
+        message: `Unknown coin selection algorithm: ${algorithm}`,
+        cause: { algorithm }
+      })
+  }
+}
+
+/**
+ * Resolve coin selection function from options.
+ * Returns the configured algorithm or defaults to largest-first.
+ */
+const resolveCoinSelectionFn = (
+  coinSelection?: CoinSelectionAlgorithm | CoinSelectionFunction
+): CoinSelectionFunction => {
+  if (!coinSelection) return largestFirstSelection
+  if (typeof coinSelection === "function") return coinSelection
+  return getCoinSelectionAlgorithm(coinSelection)
+}
+
+/**
+ * Add selected UTxOs to transaction context state.
+ * Updates both the selected UTxOs list and total input assets.
+ */
+const addUtxosToState = (selectedUtxos: ReadonlyArray<UTxO.UTxO>): Effect.Effect<void, never, TxContext> =>
+  Effect.gen(function* () {
+    const ctx = yield* TxContext
+
+    // Log each UTxO being added
+    for (const utxo of selectedUtxos) {
+      const txHash = utxo.txHash
+      const outputIndex = utxo.outputIndex
+      yield* Effect.logDebug(`[Selection] Adding UTxO: ${txHash}#${outputIndex}, ${formatAssetsForLog(utxo.assets)}.`)
+    }
+
+    // Calculate total assets from selected UTxOs
+    const additionalAssets = calculateTotalAssets(selectedUtxos)
+
+    // Update state with new UTxOs and input assets
+    yield* Ref.update(ctx, (state) => ({
+      ...state,
+      selectedUtxos: [...state.selectedUtxos, ...selectedUtxos],
+      totalInputAssets: Assets.add(state.totalInputAssets, additionalAssets)
+    }))
+  })
+
+/**
+ * Helper: Perform coin selection and update TxContext.state
+ */
+const performCoinSelectionUpdateState = (assetShortfalls: Assets.Assets) =>
+  Effect.gen(function* () {
+    const ctx = yield* TxContext
+    const state = yield* Ref.get(ctx)
+    const alreadySelected = state.selectedUtxos
+
+    // Get resolved availableUtxos from context tag
+    const allAvailableUtxos = yield* AvailableUtxosTag
+    const buildOptions = yield* BuildOptionsTag
+    const availableUtxos = getAvailableUtxos(allAvailableUtxos, alreadySelected)
+    const coinSelectionFn = resolveCoinSelectionFn(buildOptions.coinSelection)
+
+    const { selectedUtxos } = yield* Effect.try({
+      try: () => coinSelectionFn(availableUtxos, assetShortfalls),
+      catch: (error) => {
+        // Custom serialization for Assets (handles BigInt)
+        return new TransactionBuilderError({
+          message: `Coin selection failed for ${formatAssetsForLog(assetShortfalls)}`,
+          cause: error
+        })
+      }
+    })
+
+    yield* addUtxosToState(selectedUtxos)
+  })
+
+/**
+ * Selection Phase - UTxO Coin Selection
+ *
+ * Selects UTxOs from available pool to cover transaction outputs, fees, and change requirements.
+ * Handles both initial selection and reselection with retry logic up to MAX_ATTEMPTS.
+ *
+ * **Decision Flow:**
+ * ```
+ * Calculate Required Assets
+ * (outputs + shortfall for fees/change)
+ *   ↓
+ * Assets Sufficient?
+ * (inputs >= required)
+ *   ├─ YES → No selection needed
+ *   │        (use existing explicit inputs only)
+ *   │        goto changeCreation
+ *   └─ NO → Calculate asset delta
+ *           ├─ Shortfall from fees? → Reselection mode
+ *           │  (select more lovelace for change minUTxO)
+ *           └─ Shortfall from outputs? → Normal selection
+ *              (select missing native assets or lovelace)
+ *           ↓
+ *        Perform coin selection
+ *        (update totalInputAssets)
+ *        ↓
+ *        Increment attempt counter
+ *        goto changeCreation
+ * ```
+ *
+ * **Key Principles:**
+ * - Selection phase runs once per state machine iteration
+ * - Reselection (shortfall > 0) adds more UTxOs within MAX_ATTEMPTS limit
+ * - Selection itself doesn't fail; ChangeCreation may trigger reselection
+ * - No selection needed if explicit inputs already cover requirements
+ * - Shortfall tracks lovelace deficit for change output minUTxO
+ * - Asset delta identifies what additional UTxOs must contain
+ * - Attempt counter resets at phase start, incremented at phase end
+ * - Selection is deterministic (same inputs = same selection)
+ */
+export const executeSelection = (): Effect.Effect<PhaseResult, TransactionBuilderError, PhaseContextTag | TxContext | AvailableUtxosTag | BuildOptionsTag> =>
+  Effect.gen(function* () {
+    const ctx = yield* TxContext
+    const buildCtxRef = yield* PhaseContextTag
+    const buildCtx = yield* Ref.get(buildCtxRef)
+
+    const state = yield* Ref.get(ctx)
+    const inputAssets = state.totalInputAssets
+    const outputAssets = state.totalOutputAssets
+
+    // Step 3: Calculate total needed (outputs + shortfall)
+    // Shortfall contains fee + any missing lovelace for change outputs
+    const totalNeeded: Assets.Assets = {
+      ...outputAssets,
+      lovelace: outputAssets.lovelace + buildCtx.shortfall
+    }
+
+    // Step 4: Calculate asset delta & extract shortfalls
+    const assetDelta = Assets.subtract(totalNeeded, inputAssets)
+    const assetShortfalls = Assets.filter(assetDelta, (_unit, amount) => amount > 0n)
+
+    // During reselection (shortfall > 0), we need to select MORE lovelace
+    // even if inputAssets >= totalNeeded, because the shortfall indicates
+    // insufficient lovelace for change output minUTxO requirement
+    const isReselection = buildCtx.shortfall > 0n
+    const needsSelection = !Assets.isEmpty(assetShortfalls) || isReselection
+
+    yield* Effect.logDebug(
+      `[Selection] Needed: {${formatAssetsForLog(totalNeeded)}}, ` +
+        `Available: {${formatAssetsForLog(inputAssets)}}, ` +
+        `Delta: {${formatAssetsForLog(assetDelta)}}` +
+        (isReselection ? `, Reselection: shortfall=${buildCtx.shortfall}` : "")
+    )
+
+    // Step 5: Perform selection or skip
+    if (!needsSelection) {
+      yield* Effect.logDebug("[Selection] Assets sufficient")
+      const state = yield* Ref.get(ctx)
+      const selectedUtxos = state.selectedUtxos
+      yield* Effect.logDebug(
+        `[Selection] No selection needed: ${selectedUtxos.length} UTxO(s) already available from explicit inputs (collectFrom), ` +
+          `Total lovelace: ${inputAssets.lovelace || 0n}`
+      )
+    } else {
+      if (isReselection) {
+        yield* Effect.logDebug(
+          `[Selection] Reselection attempt ${buildCtx.attempt + 1}: ` +
+            `Need ${buildCtx.shortfall} more lovelace for change minUTxO`
+        )
+        // During reselection, select for the shortfall amount only
+        const reselectionShortfall: Assets.Assets = { lovelace: buildCtx.shortfall }
+        yield* performCoinSelectionUpdateState(reselectionShortfall)
+      } else {
+        yield* Effect.logDebug(`[Selection] Selecting for shortfall: ${formatAssetsForLog(assetShortfalls)}`)
+        yield* performCoinSelectionUpdateState(assetShortfalls)
+      }
+    }
+
+    // Step 6: Update context and proceed
+    yield* Ref.update(buildCtxRef, (ctx) => ({ ...ctx, attempt: ctx.attempt + 1, shortfall: 0n }))
+
+    return { next: "changeCreation" as const }
+  })

--- a/packages/evolution/src/sdk/client/Client.ts
+++ b/packages/evolution/src/sdk/client/Client.ts
@@ -3,8 +3,7 @@
 
 import { Data, type Effect, type Schedule } from "effect"
 
-import type { TransactionBuilder } from "../builders/TransactionBuilder.js"
-import type { TransactionResultBase } from "../builders/TransactionResult.js"
+import type { ReadOnlyTransactionBuilder, SigningTransactionBuilder } from "../builders/TransactionBuilder.js"
 import type * as Delegation from "../Delegation.js"
 import type * as Provider from "../provider/Provider.js"
 import type { EffectToPromiseAPI } from "../Type.js"
@@ -128,9 +127,6 @@ export type ReadOnlyClient = EffectToPromiseAPI<ReadOnlyClientEffect> & {
    * - `.toTransactionWithFakeWitnesses()` - Get transaction with fake witnesses for fee validation
    * - `.estimateFee()` - Get the calculated fee
    *
-   * @param utxos - Optional UTxOs to use for coin selection. If not provided, wallet UTxOs will be fetched automatically when build() is called.
-   * @returns A new TransactionBuilder instance configured with cached protocol parameters and wallet change address.
-   *
    * @example
    * ```typescript
    * // Build unsigned transaction
@@ -149,7 +145,7 @@ export type ReadOnlyClient = EffectToPromiseAPI<ReadOnlyClientEffect> & {
    * @since 2.0.0
    * @category transaction-building
    */
-  readonly newTx: (utxos?: ReadonlyArray<UTxO.UTxO>) => TransactionBuilder<TransactionResultBase>
+  readonly newTx: (utxos?: ReadonlyArray<UTxO.UTxO>) => ReadOnlyTransactionBuilder
   // Effect namespace - includes all provider + wallet methods as Effects
   readonly Effect: ReadOnlyClientEffect
 }
@@ -196,7 +192,7 @@ export type SigningClient = EffectToPromiseAPI<SigningClientEffect> & {
    * @since 2.0.0
    * @category transaction-building
    */
-  readonly newTx: () => TransactionBuilder
+  readonly newTx: () => SigningTransactionBuilder
   // Effect namespace - includes all provider + wallet methods as Effects
   readonly Effect: SigningClientEffect
 }

--- a/packages/evolution/src/sdk/client/ClientImpl.ts
+++ b/packages/evolution/src/sdk/client/ClientImpl.ts
@@ -12,9 +12,7 @@ import * as VKey from "../../core/VKey.js"
 import { runEffect } from "../../utils/effect-runtime.js"
 import { hashTransaction } from "../../utils/Hash.js"
 import type * as Address from "../Address.js"
-import type { SignBuilder } from "../builders/SignBuilder.js"
-import { makeTxBuilder, type TransactionBuilder } from "../builders/TransactionBuilder.js"
-import type { TransactionResultBase } from "../builders/TransactionResult.js"
+import { makeTxBuilder, type ReadOnlyTransactionBuilder, type SigningTransactionBuilder } from "../builders/TransactionBuilder.js"
 import * as Blockfrost from "../provider/Blockfrost.js"
 import * as Koios from "../provider/Koios.js"
 import * as Kupmios from "../provider/Kupmios.js"
@@ -196,11 +194,11 @@ const createReadOnlyClient = (
       return provider.getDelegation(rewardAddr)
     },
     // Transaction builder - creates a new builder instance
-    newTx: (): TransactionBuilder<TransactionResultBase> => {
+    newTx: (): ReadOnlyTransactionBuilder => {
       // ReadOnlyWallet provides change address and UTxO fetching via wallet.Effect.address()
       // The wallet is passed to the builder config, which handles address and UTxO resolution automatically
       // Protocol parameters are auto-fetched from provider during build()
-      return makeTxBuilder<TransactionResultBase>({
+      return makeTxBuilder({
         wallet,
         provider
       })
@@ -659,11 +657,11 @@ const createSigningClient = (
     getWalletUtxos,
     getWalletDelegation: () => Effect.runPromise(effectInterface.getWalletDelegation()),
     // Transaction builder - creates a new builder instance
-    newTx: (): TransactionBuilder<SignBuilder> => {
+    newTx: (): SigningTransactionBuilder => {
       // Wallet provides change address and UTxO fetching via wallet.Effect.address()
       // The wallet is passed to the builder config, which handles address and UTxO resolution automatically
       // Protocol parameters are auto-fetched from provider during build()
-      return makeTxBuilder<SignBuilder>({
+      return makeTxBuilder({
         provider, // Pass provider for submission
         wallet // Pass wallet for signing
       })

--- a/packages/evolution/src/sdk/provider/Blockfrost.ts
+++ b/packages/evolution/src/sdk/provider/Blockfrost.ts
@@ -48,12 +48,6 @@ export class BlockfrostProvider implements Provider {
   readonly baseUrl: string
   readonly projectId?: string
 
-  /**
-   * Create a new Blockfrost provider instance
-   * 
-   * @param baseUrl - The Blockfrost API base URL (e.g., "https://cardano-mainnet.blockfrost.io/api/v0")
-   * @param projectId - Optional project ID for authenticated requests
-   */
   constructor(baseUrl: string, projectId?: string) {
     this.baseUrl = baseUrl
     this.projectId = projectId
@@ -115,33 +109,24 @@ export class BlockfrostProvider implements Provider {
 
 /**
  * Pre-configured Blockfrost provider for Cardano mainnet
- * @param projectId - Your Blockfrost project ID
- * @returns Configured BlockfrostProvider for mainnet
  */
 export const mainnet = (projectId: string): BlockfrostProvider =>
   new BlockfrostProvider("https://cardano-mainnet.blockfrost.io/api/v0", projectId)
 
 /**
  * Pre-configured Blockfrost provider for Cardano preprod testnet
- * @param projectId - Your Blockfrost project ID for preprod
- * @returns Configured BlockfrostProvider for preprod
  */
 export const preprod = (projectId: string): BlockfrostProvider =>
   new BlockfrostProvider("https://cardano-preprod.blockfrost.io/api/v0", projectId)
 
 /**
  * Pre-configured Blockfrost provider for Cardano preview testnet
- * @param projectId - Your Blockfrost project ID for preview
- * @returns Configured BlockfrostProvider for preview
  */
 export const preview = (projectId: string): BlockfrostProvider =>
   new BlockfrostProvider("https://cardano-preview.blockfrost.io/api/v0", projectId)
 
 /**
  * Create a custom Blockfrost provider with custom base URL
- * @param baseUrl - Custom Blockfrost API base URL
- * @param projectId - Optional project ID
- * @returns Configured BlockfrostProvider
  */
 export const custom = (baseUrl: string, projectId?: string): BlockfrostProvider =>
   new BlockfrostProvider(baseUrl, projectId)

--- a/packages/evolution/src/sdk/provider/Maestro.ts
+++ b/packages/evolution/src/sdk/provider/Maestro.ts
@@ -52,13 +52,6 @@ import type { Provider, ProviderEffect } from "./Provider.js"
 export class MaestroProvider implements Provider {
   readonly Effect: ProviderEffect
 
-  /**
-   * Create a new Maestro provider instance
-   *
-   * @param baseUrl - The Maestro API base URL (e.g., "https://api.maestro.org/v1")
-   * @param apiKey - API key for authenticated requests
-   * @param turboSubmit - Optional flag to enable turbo submit (default: false)
-   */
   constructor(
     private readonly baseUrl: string,
     private readonly apiKey: string,

--- a/packages/evolution/src/sdk/provider/internal/Maestro.ts
+++ b/packages/evolution/src/sdk/provider/internal/Maestro.ts
@@ -157,11 +157,6 @@ export const MaestroEvalResult = Schema.Array(Schema.Unknown)
 // Transformation Utilities
 // ============================================================================
 
-/**
- * Parse decimal from Maestro's rational string format
- * @param rationalStr Format: "numerator/denominator"
- * @returns Decimal number
- */
 export const parseDecimalFromRational = (rationalStr: string): number => {
   const forwardSlashIndex = rationalStr.indexOf("/")
   if (forwardSlashIndex === -1) {

--- a/packages/evolution/src/utils/effect-runtime.ts
+++ b/packages/evolution/src/utils/effect-runtime.ts
@@ -93,10 +93,6 @@ function cleanErrorChain(error: any): any {
  * }
  * ```
  * 
- * @param effect - The Effect to execute
- * @returns Promise that resolves to the Effect's success value
- * @throws The Effect's error with cleaned stack trace
- * 
  * @since 2.0.0
  * @category utilities
  */

--- a/packages/evolution/test/TxBuilder.CoinSelectionFailures.test.ts
+++ b/packages/evolution/test/TxBuilder.CoinSelectionFailures.test.ts
@@ -33,7 +33,7 @@ describe("Insufficient Lovelace", () => {
       assets: Assets.fromLovelace(5_000_000n)
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 
   it("should fail when lovelace covers payment but not payment + fees", async () => {
@@ -47,7 +47,7 @@ describe("Insufficient Lovelace", () => {
       assets: Assets.fromLovelace(1_950_000n)
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Cannot create valid change/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Cannot create valid change/)
   })
 
   it("should fail with multiple small UTxOs that sum to insufficient amount", async () => {
@@ -65,7 +65,7 @@ describe("Insufficient Lovelace", () => {
       assets: Assets.fromLovelace(1_000_000n)
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 })
 
@@ -98,7 +98,7 @@ describe("Missing Native Assets", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 
   it("should fail when multiple assets requested but one is missing", async () => {
@@ -137,7 +137,7 @@ describe("Missing Native Assets", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 })
 
@@ -167,7 +167,7 @@ describe("Insufficient Native Asset Quantity", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 
   it("should fail when tokens are fragmented across UTxOs but total is insufficient", async () => {
@@ -209,7 +209,7 @@ describe("Insufficient Native Asset Quantity", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 
   it("should fail when one of multiple required assets is insufficient", async () => {
@@ -244,7 +244,7 @@ describe("Insufficient Native Asset Quantity", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 })
 
@@ -258,7 +258,7 @@ describe("Complex Mixed Failures", () => {
     })
 
     // Empty wallet fails coin selection
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed/)
   })
 
   it("should fail when UTxOs exist but all are too small for min UTxO + fees", async () => {
@@ -273,7 +273,7 @@ describe("Complex Mixed Failures", () => {
       assets: Assets.fromLovelace(50_000n)
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 
   it("should fail with sufficient lovelace but missing native asset", async () => {
@@ -295,7 +295,7 @@ describe("Complex Mixed Failures", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 
   it("should fail when combined shortfalls across lovelace and multiple assets", async () => {
@@ -330,7 +330,7 @@ describe("Complex Mixed Failures", () => {
       assets: paymentAssets
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 })
 
@@ -349,7 +349,7 @@ describe("Edge Case: drainTo Cannot Save Insufficient Funds", () => {
     })
 
     await expect(
-      builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, drainTo: 0, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS }) // drainTo cannot save this
+      builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, drainTo: 0, protocolParameters: PROTOCOL_PARAMS }) // drainTo cannot save this
     ).rejects.toThrow(/Coin selection failed for/)
   })
 
@@ -365,6 +365,6 @@ describe("Edge Case: drainTo Cannot Save Insufficient Funds", () => {
       assets: Assets.fromLovelace(2_000_000n)
     })
 
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useStateMachine: true, useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow(/Coin selection failed for/)
   })
 })

--- a/packages/evolution/test/TxBuilder.EdgeCases.test.ts
+++ b/packages/evolution/test/TxBuilder.EdgeCases.test.ts
@@ -43,7 +43,7 @@ describe("TxBuilder P0 Edge Cases - Reselection Loop Boundaries", () => {
           address: RECEIVER_ADDRESS,
           assets: Assets.fromLovelace(5_000_000n)
         })
-        .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+        .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
     ).rejects.toThrow()
   })
 
@@ -144,7 +144,7 @@ describe("TxBuilder P0 Edge Cases - Reselection Loop Boundaries", () => {
         address: RECEIVER_ADDRESS,
         assets: paymentAssets
       })
-      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
 
     const tx = await signBuilder.toTransaction()
 
@@ -202,7 +202,7 @@ describe("TxBuilder P0 Edge Cases - MinUTxO Boundary Precision", () => {
         address: RECEIVER_ADDRESS,
         assets: { lovelace: 1_000_000n }
       })
-      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
 
     const tx = await signBuilder.toTransaction()
 
@@ -279,7 +279,7 @@ describe("TxBuilder P0 Edge Cases - MinUTxO Boundary Precision", () => {
         address: RECEIVER_ADDRESS,
         assets: { lovelace: 2_000_000n }
       })
-      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
 
     const tx = await signBuilder.toTransaction()
 
@@ -366,7 +366,7 @@ describe("TxBuilder P0 Edge Cases - MinUTxO Boundary Precision", () => {
         address: RECEIVER_ADDRESS,
         assets: { lovelace: 4_000_000n } // 4.0 ADA (no native assets in payment)
       })
-      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+      .build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
 
     const tx = await signBuilder.toTransaction()
 

--- a/packages/evolution/test/TxBuilder.InsufficientChange.test.ts
+++ b/packages/evolution/test/TxBuilder.InsufficientChange.test.ts
@@ -91,7 +91,7 @@ describe("Fallback Tier 3: onInsufficientChange Strategy", () => {
 
     // Act & Assert: Should fail with default 'error' strategy
     // This is the SAFE default - prevents accidental fund loss
-    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], useV3: true, protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow()
+    await expect(builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], protocolParameters: PROTOCOL_PARAMS })).rejects.toThrow()
   })
 
   it("should burn leftover as extra fee when onInsufficientChange='burn'", async () => {
@@ -104,7 +104,7 @@ describe("Fallback Tier 3: onInsufficientChange Strategy", () => {
       })
 
     // Act: Explicitly consent to burning leftover
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], onInsufficientChange: "burn", useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], onInsufficientChange: "burn", protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 
@@ -145,7 +145,6 @@ describe("Fallback Precedence: drainTo before onInsufficientChange", () => {
       availableUtxos: [utxo],
       drainTo: 0, // Fallback #1: Drain into first output
       onInsufficientChange: "error", // Fallback #2: Would error, but shouldn't reach here
-      useV3: true,
       protocolParameters: PROTOCOL_PARAMS
     })
 
@@ -182,7 +181,6 @@ describe("Normal Path: Sufficient Change (No Fallbacks)", () => {
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxo],
       onInsufficientChange: "error", // Configured but not reached
-      useV3: true,
       protocolParameters: PROTOCOL_PARAMS
     })
 
@@ -217,7 +215,7 @@ describe("Normal Path: Sufficient Change (No Fallbacks)", () => {
       })
 
     // Act: Use drainTo for exact amount scenarios
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], drainTo: 0, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], drainTo: 0, protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 
@@ -262,7 +260,7 @@ describe("Edge Cases", () => {
 
     // Act: Build with drainTo to merge leftover into payment
     // Total: 2.2 ADA - 2.0 payment - 0.17 fee = 0.03 ADA leftover (insufficient for change)
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, drainTo: 0, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, drainTo: 0, protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 
@@ -290,7 +288,7 @@ describe("Edge Cases", () => {
       })
 
     // Act: Burn small leftover
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], onInsufficientChange: "burn", useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [utxo], onInsufficientChange: "burn", protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 
@@ -346,7 +344,7 @@ describe("Multi-Asset minUTxO Calculation", () => {
       })
 
     // Act: Build transaction
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [multiAssetUtxo], useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: [multiAssetUtxo], protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 
@@ -419,7 +417,7 @@ describe("Fee Validation: Multiple Witnesses Edge Case", () => {
       })
 
     // Act: Build transaction
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 
@@ -471,7 +469,7 @@ describe("Fee Validation: Multiple Witnesses Edge Case", () => {
       })
 
     // Act
-    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, useV3: true, protocolParameters: PROTOCOL_PARAMS })
+    const signBuilder = await builder.build({ changeAddress: CHANGE_ADDRESS, availableUtxos: utxos, protocolParameters: PROTOCOL_PARAMS })
     const tx = await signBuilder.toTransaction()
     const txWithFakeWitnesses = await signBuilder.toTransactionWithFakeWitnesses()
 

--- a/packages/evolution/test/TxBuilder.Reselection.test.ts
+++ b/packages/evolution/test/TxBuilder.Reselection.test.ts
@@ -76,7 +76,6 @@ describe("TxBuilder Re-selection Loop", () => {
       })
 
       const signBuilder = await builder.build({
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo],
         protocolParameters: PROTOCOL_PARAMS
@@ -132,7 +131,6 @@ describe("TxBuilder Re-selection Loop", () => {
 
       const signBuilder = await builder.build({
         drainTo: 0,
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo1, utxo2, utxo3],
         protocolParameters: PROTOCOL_PARAMS
@@ -173,7 +171,6 @@ describe("TxBuilder Re-selection Loop", () => {
 
       await expect(
         builder.build({
-          useV3: true,
           changeAddress: CHANGE_ADDRESS,
           availableUtxos: [utxo],
           protocolParameters: PROTOCOL_PARAMS
@@ -201,7 +198,6 @@ describe("TxBuilder Re-selection Loop", () => {
 
       const signBuilder = await builder.build({
         drainTo: 0,
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo],
         protocolParameters: PROTOCOL_PARAMS
@@ -253,7 +249,6 @@ describe("TxBuilder Re-selection Loop", () => {
       // Expected: Transaction succeeds with change output preserving native asset
       const signBuilder = await builder.build({
         drainTo: 0,
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo],
         protocolParameters: PROTOCOL_PARAMS
@@ -307,7 +302,6 @@ describe("TxBuilder Re-selection Loop", () => {
       })
 
       const signBuilder = await builder.build({
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo1, utxo2],
         protocolParameters: PROTOCOL_PARAMS
@@ -376,7 +370,6 @@ describe("TxBuilder Re-selection Loop", () => {
       })
 
       const signBuilder = await builder.build({
-        useV3: true,
         availableUtxos: [utxo1, utxo2],
         changeAddress: CHANGE_ADDRESS,
         protocolParameters: PROTOCOL_PARAMS
@@ -421,7 +414,6 @@ describe("TxBuilder Re-selection Loop", () => {
       })
 
       const signBuilder = await builder.build({
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: utxos,
         protocolParameters: PROTOCOL_PARAMS
@@ -467,7 +459,6 @@ describe("TxBuilder Re-selection Loop", () => {
       })
 
       const signBuilder = await builder.build({
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo1, utxo2],
         protocolParameters: PROTOCOL_PARAMS
@@ -532,7 +523,6 @@ describe("TxBuilder Re-selection Loop", () => {
       // With 140+ unique addresses selected, we get 140+ fake witnesses pushing size over 16384 bytes
       await expect(
         builder.build({
-          useV3: true,
           changeAddress: CHANGE_ADDRESS,
           availableUtxos: utxos,
           protocolParameters: PROTOCOL_PARAMS
@@ -573,7 +563,6 @@ describe("TxBuilder Re-selection Loop", () => {
       // Use drainTo since the change will be small (33K < minUTxO)
       const signBuilder = await builder.build({
         drainTo: 0,
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: utxos,
         protocolParameters: PROTOCOL_PARAMS
@@ -631,7 +620,6 @@ describe("TxBuilder Re-selection Loop", () => {
 
       // Build should succeed after multiple reselection attempts
       const signBuilder = await builder.build({
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: tinyUtxos,
         protocolParameters: PROTOCOL_PARAMS
@@ -681,7 +669,6 @@ describe("TxBuilder Re-selection Loop", () => {
       })
 
       const signBuilder = await builder.build({
-        useV3: true,
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: utxos,
         protocolParameters: PROTOCOL_PARAMS
@@ -739,8 +726,6 @@ describe("TxBuilder Reselection After Change", () => {
     })
 
     const signBuilder = await builder.build({
-      useStateMachine: true,
-      useV3: true,
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [largeUtxo],
       protocolParameters: PROTOCOL_PARAMS
@@ -797,8 +782,6 @@ describe("TxBuilder Reselection After Change", () => {
     })
 
     const signBuilder = await builder.build({
-      useStateMachine: true,
-      useV3: true,
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxo1, utxo2, utxo3],
       protocolParameters: PROTOCOL_PARAMS
@@ -840,8 +823,6 @@ describe("TxBuilder Reselection After Change", () => {
     })
 
     const signBuilder = await builder.build({
-      useStateMachine: true,
-      useV3: true,
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxoWithAssets],
       protocolParameters: PROTOCOL_PARAMS
@@ -892,8 +873,6 @@ describe("TxBuilder Reselection After Change", () => {
     })
 
     const signBuilder = await builder.build({
-      useStateMachine: true,
-      useV3: true,
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxo1, utxo2],
       protocolParameters: PROTOCOL_PARAMS

--- a/packages/evolution/test/TxBuilder.UnfrackChangeHandling.test.ts
+++ b/packages/evolution/test/TxBuilder.UnfrackChangeHandling.test.ts
@@ -68,8 +68,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: additionalUtxos, // Available for re-selection
-        useV3: true,
-        useStateMachine: true,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
           ada: {
@@ -145,8 +143,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: tinyUtxos, // Available but won't be used
-        useV3: true,
-        useStateMachine: true,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
           ada: {
@@ -210,8 +206,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
         await builder.build({
           changeAddress: CHANGE_ADDRESS,
           availableUtxos: [], // No more UTxOs available
-          useV3: true,
-          useStateMachine: true,
           protocolParameters: PROTOCOL_PARAMS,
           unfrack: {
             ada: {
@@ -249,8 +243,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [],
-        useV3: true,
-        useStateMachine: true,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
           ada: {
@@ -292,8 +284,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [],
-        useV3: true,
-        useStateMachine: true,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
           ada: {
@@ -332,8 +322,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [],
-        useV3: true,
-        useStateMachine: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -374,8 +362,6 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [],
-        useV3: true,
-        useStateMachine: true,
         onInsufficientChange: "burn",
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {

--- a/packages/evolution/test/TxBuilder.UnfrackDrain.test.ts
+++ b/packages/evolution/test/TxBuilder.UnfrackDrain.test.ts
@@ -145,7 +145,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -154,7 +153,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdividePercentages: [50, 30, 20] // Split into 3 outputs
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -203,7 +201,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -211,7 +208,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdivideThreshold: 100_000_000n // 100 ADA threshold
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -252,7 +248,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -263,7 +258,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdivideThreshold: 100_000_000n // 100 ADA
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -295,7 +289,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -307,7 +300,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdivideThreshold: 100_000_000n
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -339,7 +331,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -351,7 +342,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdivideThreshold: 100_000_000n
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -383,7 +373,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -397,7 +386,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdividePercentages: [40, 25, 15, 10, 10] // Flexible ADA distribution
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -441,11 +429,9 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         // No unfrack options
         protocolParameters: PROTOCOL_PARAMS,
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -482,7 +468,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -494,7 +479,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdividePercentages: [60, 40]
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -538,7 +522,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -546,7 +529,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdivideThreshold: 100_000_000n // 100 ADA (leftover is ~5 ADA)
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -583,7 +565,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0, // Drain into first payment output
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -594,7 +575,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdivideThreshold: 100_000_000n
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -637,7 +617,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -646,7 +625,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdividePercentages: [25, 25, 25, 25]
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -687,7 +665,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -701,7 +678,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdividePercentages: [50, 25, 15, 10] // 4-way split
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()
@@ -736,7 +712,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
       const signBuilder = await builder.build({
         changeAddress: SOURCE_ADDRESS,
         availableUtxos: utxos,
-        useV3: true,
         drainTo: 0,
         protocolParameters: PROTOCOL_PARAMS,
         unfrack: {
@@ -750,7 +725,6 @@ describe("TxBuilder Unfrack + DrainTo Integration", () => {
             subdividePercentages: [35, 25, 20, 10, 10] // 5-way split for flexibility
           }
         },
-        useStateMachine: true
       })
 
       const tx = await signBuilder.toTransaction()

--- a/packages/evolution/test/TxBuilder.UnfrackMinUTxO.test.ts
+++ b/packages/evolution/test/TxBuilder.UnfrackMinUTxO.test.ts
@@ -89,8 +89,7 @@ describe.concurrent("TxBuilder - Unfrack MinUTxO", () => {
     const signBuilder = await builder.build({ 
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxo1, utxo2],
-      useV3: true, 
-      useStateMachine: true,
+      
       protocolParameters: PROTOCOL_PARAMS,
       unfrack: {
         tokens: {
@@ -190,8 +189,7 @@ describe.concurrent("TxBuilder - Unfrack MinUTxO", () => {
     const signBuilder = await builder.build({ 
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxo1, utxo2, utxo3],
-      useV3: true, 
-      useStateMachine: true,
+      
       protocolParameters: PROTOCOL_PARAMS,
       unfrack: {
         tokens: {
@@ -256,8 +254,7 @@ describe.concurrent("TxBuilder - Unfrack MinUTxO", () => {
     const signBuilder = await builder.build({ 
       changeAddress: CHANGE_ADDRESS,
       availableUtxos: [utxo],
-      useV3: true, 
-      useStateMachine: true,
+      
       protocolParameters: PROTOCOL_PARAMS,
       drainTo: 0 // Request drain into first output
     })
@@ -305,8 +302,7 @@ describe.concurrent("TxBuilder - Unfrack MinUTxO", () => {
       builder.build({ 
         changeAddress: CHANGE_ADDRESS,
         availableUtxos: [utxo],
-        useV3: true, 
-        useStateMachine: true,
+        
         protocolParameters: PROTOCOL_PARAMS,
         onInsufficientChange: "burn"
       })


### PR DESCRIPTION
Modularizes the transaction builder phase implementation by extracting each phase (Selection, ChangeCreation, FeeCalculation, Balance, Fallback) into separate files for improved maintainability and testability.