### PR TITLE
feat: add CIP-129 bech32 for governance

### DIFF
--- a/packages/evolution/src/core/CommitteeColdCredential.ts
+++ b/packages/evolution/src/core/CommitteeColdCredential.ts
@@ -4,9 +4,192 @@
  * In Cardano, committee_cold_credential = credential, representing the same credential structure
  * but used specifically for committee cold keys in governance.
  *
+ * Implements CIP-129 bech32 encoding with "cc_cold" prefix.
+ *
  * @since 2.0.0
  */
 
+import { bech32 } from "@scure/base"
+import * as Effect from "effect/Effect"
+import * as ParseResult from "effect/ParseResult"
+import * as Schema from "effect/Schema"
+
 import * as Credential from "./Credential.js"
+import * as KeyHash from "./KeyHash.js"
+import * as ScriptHash from "./ScriptHash.js"
 
 export const CommitteeColdCredential = Credential
+
+// ============================================================================
+// CIP-129 Bech32 Support
+// ============================================================================
+
+/**
+ * Transform from CIP-129 bytes (29 bytes) to Committee Cold Credential.
+ * Format: [header_byte(1)][credential_bytes(28)]
+ * Header byte for cc_cold:
+ *   - 0x1C = KeyHash (bits: 0001 1100 = key type 0x01, cred type 0x0C)
+ *   - 0x1D = ScriptHash (bits: 0001 1101 = key type 0x01, cred type 0x0D)
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromBytes = Schema.transformOrFail(Schema.Uint8ArrayFromSelf, Schema.typeSchema(Credential.CredentialSchema), {
+  strict: true,
+  encode: (toI, _, ast) =>
+    Effect.gen(function* () {
+      // Encode: Credential → 29 bytes with cc_cold header
+      const credBytes = toI.hash
+
+      if (credBytes.length !== 28) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, toI, `Invalid credential hash length: expected 28 bytes, got ${credBytes.length}`)
+        )
+      }
+
+      const header = toI._tag === "KeyHash" ? 0x1c : 0x1d
+      const result = new Uint8Array(29)
+      result[0] = header
+      result.set(credBytes, 1)
+      return result
+    }),
+  decode: (fromA, _, ast) =>
+    Effect.gen(function* () {
+      // Decode: 29 bytes → Credential
+      if (fromA.length !== 29) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Invalid cc_cold credential length: expected 29 bytes, got ${fromA.length}`)
+        )
+      }
+
+      const header = fromA[0]
+      const credBytes = fromA.slice(1)
+
+      // Validate header byte
+      const keyType = (header >> 4) & 0x0f
+      const credType = header & 0x0f
+
+      if (keyType !== 0x01) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Invalid key type in header: expected 0x01 (CC Cold), got 0x0${keyType.toString(16)}`)
+        )
+      }
+
+      if (credType === 0x0c) {
+        const keyHash = yield* ParseResult.decode(KeyHash.FromBytes)(credBytes)
+        return new KeyHash.KeyHash({ hash: keyHash.hash })
+      } else if (credType === 0x0d) {
+        const scriptHash = yield* ParseResult.decode(ScriptHash.FromBytes)(credBytes)
+        return new ScriptHash.ScriptHash({ hash: scriptHash.hash })
+      }
+
+      return yield* ParseResult.fail(
+        new ParseResult.Type(ast, fromA, `Invalid credential type in header: expected 0x0C or 0x0D, got 0x0${credType.toString(16)}`)
+      )
+    })
+}).annotations({
+  identifier: "CommitteeColdCredential.FromBytes",
+  description: "Transforms CIP-129 bytes to Committee Cold Credential"
+})
+
+/**
+ * Transform from hex string to Committee Cold Credential.
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromHex = Schema.compose(Schema.Uint8ArrayFromHex, FromBytes).annotations({
+  identifier: "CommitteeColdCredential.FromHex",
+  description: "Transforms hex string to Committee Cold Credential"
+})
+
+/**
+ * Transform from Bech32 string to Committee Cold Credential following CIP-129.
+ * Bech32 prefix: "cc_cold" for both KeyHash and ScriptHash
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromBech32 = Schema.transformOrFail(Schema.String, Schema.typeSchema(Credential.CredentialSchema), {
+  strict: true,
+  encode: (_, __, ___, toA) =>
+    Effect.gen(function* () {
+      const bytes = yield* ParseResult.encode(FromBytes)(toA)
+      const words = bech32.toWords(bytes)
+      return bech32.encode("cc_cold", words, false)
+    }),
+  decode: (fromA, _, ast) =>
+    Effect.gen(function* () {
+      const result = yield* Effect.try({
+        try: () => {
+          const decoded = bech32.decode(fromA as any, false)
+          if (decoded.prefix !== "cc_cold") {
+            throw new Error(`Invalid prefix: expected "cc_cold", got "${decoded.prefix}"`)
+          }
+          const bytes = bech32.fromWords(decoded.words)
+          return new Uint8Array(bytes)
+        },
+        catch: (error) => new ParseResult.Type(ast, fromA, `Failed to decode bech32: ${error}`)
+      })
+      return yield* ParseResult.decode(FromBytes)(result)
+    })
+}).annotations({
+  identifier: "CommitteeColdCredential.FromBech32",
+  description: "Transforms Bech32 string to Committee Cold Credential (CIP-129)"
+})
+
+// ============================================================================
+// Decoding Functions
+// ============================================================================
+
+/**
+ * Parse Committee Cold Credential from CIP-129 bytes.
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromBytes = Schema.decodeSync(FromBytes)
+
+/**
+ * Parse Committee Cold Credential from hex string.
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromHex = Schema.decodeSync(FromHex)
+
+/**
+ * Parse Committee Cold Credential from Bech32 string (CIP-129 format).
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromBech32 = Schema.decodeSync(FromBech32)
+
+// ============================================================================
+// Encoding Functions
+// ============================================================================
+
+/**
+ * Encode Committee Cold Credential to CIP-129 bytes.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBytes = Schema.encodeSync(FromBytes)
+
+/**
+ * Encode Committee Cold Credential to hex string.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toHex = Schema.encodeSync(FromHex)
+
+/**
+ * Encode Committee Cold Credential to Bech32 string (CIP-129 format).
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBech32 = Schema.encodeSync(FromBech32)

--- a/packages/evolution/src/core/CommitteeHotCredential.ts
+++ b/packages/evolution/src/core/CommitteeHotCredential.ts
@@ -4,9 +4,192 @@
  * In Cardano, committee_hot_credential = credential, representing the same credential structure
  * but used specifically for committee hot keys in governance.
  *
+ * Implements CIP-129 bech32 encoding with "cc_hot" prefix.
+ *
  * @since 2.0.0
  */
 
+import { bech32 } from "@scure/base"
+import * as Effect from "effect/Effect"
+import * as ParseResult from "effect/ParseResult"
+import * as Schema from "effect/Schema"
+
 import * as Credential from "./Credential.js"
+import * as KeyHash from "./KeyHash.js"
+import * as ScriptHash from "./ScriptHash.js"
 
 export const CommitteeHotCredential = Credential
+
+// ============================================================================
+// CIP-129 Bech32 Support
+// ============================================================================
+
+/**
+ * Transform from CIP-129 bytes (29 bytes) to Committee Hot Credential.
+ * Format: [header_byte(1)][credential_bytes(28)]
+ * Header byte for cc_hot:
+ *   - 0x1E = KeyHash (bits: 0001 1110 = key type 0x01, cred type 0x0E)
+ *   - 0x1F = ScriptHash (bits: 0001 1111 = key type 0x01, cred type 0x0F)
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromBytes = Schema.transformOrFail(Schema.Uint8ArrayFromSelf, Schema.typeSchema(Credential.CredentialSchema), {
+  strict: true,
+  encode: (toI, _, ast) =>
+    Effect.gen(function* () {
+      // Encode: Credential → 29 bytes with cc_hot header
+      const credBytes = toI.hash
+
+      if (credBytes.length !== 28) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, toI, `Invalid credential hash length: expected 28 bytes, got ${credBytes.length}`)
+        )
+      }
+
+      const header = toI._tag === "KeyHash" ? 0x1e : 0x1f
+      const result = new Uint8Array(29)
+      result[0] = header
+      result.set(credBytes, 1)
+      return result
+    }),
+  decode: (fromA, _, ast) =>
+    Effect.gen(function* () {
+      // Decode: 29 bytes → Credential
+      if (fromA.length !== 29) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Invalid cc_hot credential length: expected 29 bytes, got ${fromA.length}`)
+        )
+      }
+
+      const header = fromA[0]
+      const credBytes = fromA.slice(1)
+
+      // Validate header byte
+      const keyType = (header >> 4) & 0x0f
+      const credType = header & 0x0f
+
+      if (keyType !== 0x01) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Invalid key type in header: expected 0x01 (CC Hot), got 0x0${keyType.toString(16)}`)
+        )
+      }
+
+      if (credType === 0x0e) {
+        const keyHash = yield* ParseResult.decode(KeyHash.FromBytes)(credBytes)
+        return new KeyHash.KeyHash({ hash: keyHash.hash })
+      } else if (credType === 0x0f) {
+        const scriptHash = yield* ParseResult.decode(ScriptHash.FromBytes)(credBytes)
+        return new ScriptHash.ScriptHash({ hash: scriptHash.hash })
+      }
+
+      return yield* ParseResult.fail(
+        new ParseResult.Type(ast, fromA, `Invalid credential type in header: expected 0x0E or 0x0F, got 0x0${credType.toString(16)}`)
+      )
+    })
+}).annotations({
+  identifier: "CommitteeHotCredential.FromBytes",
+  description: "Transforms CIP-129 bytes to Committee Hot Credential"
+})
+
+/**
+ * Transform from hex string to Committee Hot Credential.
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromHex = Schema.compose(Schema.Uint8ArrayFromHex, FromBytes).annotations({
+  identifier: "CommitteeHotCredential.FromHex",
+  description: "Transforms hex string to Committee Hot Credential"
+})
+
+/**
+ * Transform from Bech32 string to Committee Hot Credential following CIP-129.
+ * Bech32 prefix: "cc_hot" for both KeyHash and ScriptHash
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromBech32 = Schema.transformOrFail(Schema.String, Schema.typeSchema(Credential.CredentialSchema), {
+  strict: true,
+  encode: (_, __, ___, toA) =>
+    Effect.gen(function* () {
+      const bytes = yield* ParseResult.encode(FromBytes)(toA)
+      const words = bech32.toWords(bytes)
+      return bech32.encode("cc_hot", words, false)
+    }),
+  decode: (fromA, _, ast) =>
+    Effect.gen(function* () {
+      const result = yield* Effect.try({
+        try: () => {
+          const decoded = bech32.decode(fromA as any, false)
+          if (decoded.prefix !== "cc_hot") {
+            throw new Error(`Invalid prefix: expected "cc_hot", got "${decoded.prefix}"`)
+          }
+          const bytes = bech32.fromWords(decoded.words)
+          return new Uint8Array(bytes)
+        },
+        catch: (error) => new ParseResult.Type(ast, fromA, `Failed to decode bech32: ${error}`)
+      })
+      return yield* ParseResult.decode(FromBytes)(result)
+    })
+}).annotations({
+  identifier: "CommitteeHotCredential.FromBech32",
+  description: "Transforms Bech32 string to Committee Hot Credential (CIP-129)"
+})
+
+// ============================================================================
+// Decoding Functions
+// ============================================================================
+
+/**
+ * Parse Committee Hot Credential from CIP-129 bytes.
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromBytes = Schema.decodeSync(FromBytes)
+
+/**
+ * Parse Committee Hot Credential from hex string.
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromHex = Schema.decodeSync(FromHex)
+
+/**
+ * Parse Committee Hot Credential from Bech32 string (CIP-129 format).
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromBech32 = Schema.decodeSync(FromBech32)
+
+// ============================================================================
+// Encoding Functions
+// ============================================================================
+
+/**
+ * Encode Committee Hot Credential to CIP-129 bytes.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBytes = Schema.encodeSync(FromBytes)
+
+/**
+ * Encode Committee Hot Credential to hex string.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toHex = Schema.encodeSync(FromHex)
+
+/**
+ * Encode Committee Hot Credential to Bech32 string (CIP-129 format).
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBech32 = Schema.encodeSync(FromBech32)

--- a/packages/evolution/src/core/DRep.ts
+++ b/packages/evolution/src/core/DRep.ts
@@ -1,3 +1,4 @@
+import { bech32 } from "@scure/base"
 import { Effect as Eff, Equal, FastCheck, Hash, Inspectable, ParseResult, Schema } from "effect"
 
 import * as CBOR from "./CBOR.js"
@@ -222,6 +223,131 @@ export const FromCBORHex = (options: CBOR.CodecOptions = CBOR.CML_DEFAULT_OPTION
   )
 
 /**
+ * Transform from raw bytes to DRep following CIP-129.
+ * CIP-129 format: [1-byte header][28-byte credential]
+ * Header byte: 0x22 = KeyHash, 0x23 = ScriptHash
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromBytes = Schema.transformOrFail(Schema.Uint8ArrayFromSelf, Schema.typeSchema(DRep), {
+  strict: true,
+  encode: (_, __, ___, toA) =>
+    Eff.gen(function* () {
+      switch (toA._tag) {
+        case "KeyHashDRep": {
+          const keyHashBytes = yield* ParseResult.encode(KeyHash.FromBytes)(toA.keyHash)
+          const result = new Uint8Array(29)
+          result[0] = 0x22 // DRep KeyHash header
+          result.set(keyHashBytes, 1)
+          return yield* ParseResult.succeed(result)
+        }
+        case "ScriptHashDRep": {
+          const scriptHashBytes = yield* ParseResult.encode(ScriptHash.FromBytes)(toA.scriptHash)
+          const result = new Uint8Array(29)
+          result[0] = 0x23 // DRep ScriptHash header
+          result.set(scriptHashBytes, 1)
+          return yield* ParseResult.succeed(result)
+        }
+        case "AlwaysAbstainDRep":
+        case "AlwaysNoConfidenceDRep":
+          return yield* ParseResult.fail(
+            new ParseResult.Type(
+              Schema.typeSchema(DRep).ast,
+              toA,
+              "AlwaysAbstain and AlwaysNoConfidence DReps cannot be encoded as bech32"
+            )
+          )
+      }
+    }),
+  decode: (fromA, _, ast) =>
+    Eff.gen(function* () {
+      if (fromA.length !== 29) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Invalid DRep bytes length: expected 29, got ${fromA.length}`)
+        )
+      }
+
+      const header = fromA[0]
+      const credential = fromA.slice(1)
+
+      // Check key type (bits [7:4]) must be 0010 (DRep)
+      const keyType = (header >> 4) & 0x0f
+      if (keyType !== 0x02) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Invalid key type in header: expected 0x02 (DRep), got 0x0${keyType.toString(16)}`)
+        )
+      }
+
+      // Check credential type (bits [3:0])
+      const credType = header & 0x0f
+
+      if (credType === 0x02) {
+        // Key Hash
+        const keyHash = yield* ParseResult.decode(KeyHash.FromBytes)(credential)
+        return new KeyHashDRep({ keyHash })
+      } else if (credType === 0x03) {
+        // Script Hash
+        const scriptHash = yield* ParseResult.decode(ScriptHash.FromBytes)(credential)
+        return new ScriptHashDRep({ scriptHash })
+      }
+
+      return yield* ParseResult.fail(
+        new ParseResult.Type(ast, fromA, `Invalid credential type in header: expected 0x02 or 0x03, got 0x0${credType.toString(16)}`)
+      )
+    })
+}).annotations({
+  identifier: "DRep.FromBytes",
+  description: "Transforms CIP-129 bytes to DRep (KeyHashDRep or ScriptHashDRep only)"
+})
+
+/**
+ * Transform from hex string to DRep.
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromHex = Schema.compose(Schema.Uint8ArrayFromHex, FromBytes).annotations({
+  identifier: "DRep.FromHex",
+  description: "Transforms hex string to DRep"
+})
+
+/**
+ * Transform from Bech32 string to DRep following CIP-129.
+ * Bech32 prefix: "drep" for both KeyHash and ScriptHash
+ *
+ * @since 2.0.0
+ * @category transformations
+ */
+export const FromBech32 = Schema.transformOrFail(Schema.String, Schema.typeSchema(DRep), {
+  strict: true,
+  encode: (_, __, ___, toA) =>
+    Eff.gen(function* () {
+      const bytes = yield* ParseResult.encode(FromBytes)(toA)
+      const words = bech32.toWords(bytes)
+      return bech32.encode("drep", words, false)
+    }),
+  decode: (fromA, _, ast) =>
+    Eff.gen(function* () {
+      const result = yield* Eff.try({
+        try: () => {
+          const decoded = bech32.decode(fromA as any, false)
+          if (decoded.prefix !== "drep") {
+            throw new Error(`Invalid prefix: expected "drep", got "${decoded.prefix}"`)
+          }
+          const bytes = bech32.fromWords(decoded.words)
+          return new Uint8Array(bytes)
+        },
+        catch: (e) => new ParseResult.Type(ast, fromA, `Failed to decode Bech32: ${e}`)
+      })
+      return yield* ParseResult.decode(FromBytes)(result)
+    })
+}).annotations({
+  identifier: "DRep.FromBech32",
+  description: "Transforms CIP-129 Bech32 string to DRep"
+})
+
+/**
  * Check if the given value is a valid DRep
  *
  * @since 2.0.0
@@ -243,7 +369,7 @@ export const arbitrary = FastCheck.oneof(
 )
 
 // ============================================================================
-// Decoding Functions
+// Parsing Functions
 // ============================================================================
 
 /**
@@ -268,14 +394,17 @@ export const fromCBORHex = (hex: string, options?: CBOR.CodecOptions): DRep =>
 // Encoding Functions
 // ============================================================================
 
+// ============================================================================
+// Encoding Functions
+// ============================================================================
+
 /**
  * Encode DRep to CBOR bytes.
  *
  * @since 2.0.0
  * @category encoding
  */
-export const toCBORBytes = (drep: DRep, options?: CBOR.CodecOptions): Uint8Array =>
-  Schema.encodeSync(FromCBORBytes(options))(drep)
+export const toCBORBytes = (options?: CBOR.CodecOptions) => Schema.encodeSync(FromCBORBytes(options))
 
 /**
  * Encode DRep to CBOR hex string.
@@ -283,8 +412,31 @@ export const toCBORBytes = (drep: DRep, options?: CBOR.CodecOptions): Uint8Array
  * @since 2.0.0
  * @category encoding
  */
-export const toCBORHex = (drep: DRep, options?: CBOR.CodecOptions): string =>
-  Schema.encodeSync(FromCBORHex(options))(drep)
+export const toCBORHex = (options?: CBOR.CodecOptions) => Schema.encodeSync(FromCBORHex(options))
+
+/**
+ * Encode DRep to CIP-129 bytes (KeyHashDRep or ScriptHashDRep only).
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBytes = Schema.encodeSync(FromBytes)
+
+/**
+ * Encode DRep to hex string.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toHex = Schema.encodeSync(FromHex)
+
+/**
+ * Encode DRep to Bech32 string (CIP-129 format).
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBech32 = Schema.encodeSync(FromBech32)
 
 /**
  * Create a KeyHashDRep from a KeyHash.
@@ -343,30 +495,6 @@ export const match =
         return patterns.AlwaysNoConfidenceDRep()
     }
   }
-
-/**
- * Check if DRep is a KeyHashDRep.
- *
- * @since 2.0.0
- * @category type guards
- */
-export const isKeyHashDRep = (drep: DRep): drep is KeyHashDRep => drep._tag === "KeyHashDRep"
-
-/**
- * Check if DRep is a ScriptHashDRep.
- *
- * @since 2.0.0
- * @category type guards
- */
-export const isScriptHashDRep = (drep: DRep): drep is ScriptHashDRep => drep._tag === "ScriptHashDRep"
-
-/**
- * Check if DRep is an AlwaysAbstainDRep.
- *
- * @since 2.0.0
- * @category type guards
- */
-export const isAlwaysAbstainDRep = (drep: DRep): drep is AlwaysAbstainDRep => drep._tag === "AlwaysAbstainDRep"
 
 /**
  * Check if DRep is an AlwaysNoConfidenceDRep.


### PR DESCRIPTION
Implements CIP-129 bech32 encoding/decoding for governance credentials.

**Depends on:** #95

- Add bech32 support to CommitteeColdCredential (cc_cold prefix)
- Add bech32 support to CommitteeHotCredential (cc_hot prefix)
- Add bech32 support to DRep (drep prefix)
- Include FromBytes, FromHex, FromBech32 schemas
- Add encoding/decoding helper functions