### PR TITLE
fix: improve X post release detection logic

### DIFF
--- a/.github/workflows/post-release-to-x.yml
+++ b/.github/workflows/post-release-to-x.yml
@@ -11,16 +11,76 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Get latest release
+      - name: Get latest release with changes
         id: release
         run: |
-          RELEASE=$(gh api /repos/${{ github.repository }}/releases/latest)
-          echo "tag=$(echo $RELEASE | jq -r .tag_name)" >> $GITHUB_OUTPUT
-          echo "url=$(echo $RELEASE | jq -r .html_url)" >> $GITHUB_OUTPUT
+          # Get the latest @evolution-sdk release with actual changes (not just dependency updates)
+          RELEASES=$(gh api /repos/${{ github.repository }}/releases --jq '[.[] | select(.tag_name | startswith("@evolution-sdk/"))]')
+          
+          # Variables to track packages
+          FALLBACK_TAG=""
+          FALLBACK_URL=""
+          EVOLUTION_TAG=""
+          EVOLUTION_URL=""
+          
+          for i in $(seq 0 10); do
+            RELEASE=$(echo $RELEASES | jq ".[$i]")
+            if [ "$RELEASE" = "null" ]; then
+              break
+            fi
+            
+            CREATED=$(echo $RELEASE | jq -r .created_at)
+            CREATED_TIMESTAMP=$(date -d "$CREATED" +%s)
+            NOW=$(date +%s)
+            AGE=$((NOW - CREATED_TIMESTAMP))
+            
+            # If created in last hour, check if it has real changes (not just dependency updates)
+            if [ $AGE -lt 3600 ]; then
+              BODY=$(echo $RELEASE | jq -r .body)
+              TAG=$(echo $RELEASE | jq -r .tag_name)
+              URL=$(echo $RELEASE | jq -r .html_url)
+              
+              # Check for actual changes (not just "Updated dependencies")
+              CHANGES_SECTION=$(echo "$BODY" | grep -A 100 "Patch Changes\|Minor Changes\|Major Changes" | tail -n +2)
+              REAL_CHANGES=$(echo "$CHANGES_SECTION" | grep -v "Updated dependencies" | grep -v "^[[:space:]]*-[[:space:]]*@" | grep -v "^[[:space:]]*$" | head -1)
+              
+              if [ -n "$REAL_CHANGES" ]; then
+                # Check if this is the main evolution package
+                if [[ "$TAG" == "@evolution-sdk/evolution@"* ]]; then
+                  if [ -z "$EVOLUTION_TAG" ]; then
+                    EVOLUTION_TAG=$TAG
+                    EVOLUTION_URL=$URL
+                  fi
+                else
+                  # Save as fallback if we haven't found one yet
+                  if [ -z "$FALLBACK_TAG" ]; then
+                    FALLBACK_TAG=$TAG
+                    FALLBACK_URL=$URL
+                  fi
+                fi
+              fi
+            fi
+          done
+          
+          # Prioritize evolution package, fall back to other packages
+          if [ -n "$EVOLUTION_TAG" ]; then
+            CLEAN_TAG=$(echo $EVOLUTION_TAG | sed 's/@//g')
+            echo "tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
+            echo "url=$EVOLUTION_URL" >> $GITHUB_OUTPUT
+            echo "found=true" >> $GITHUB_OUTPUT
+          elif [ -n "$FALLBACK_TAG" ]; then
+            CLEAN_TAG=$(echo $FALLBACK_TAG | sed 's/@//g')
+            echo "tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
+            echo "url=$FALLBACK_URL" >> $GITHUB_OUTPUT
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Tweet new release
+        if: steps.release.outputs.found == 'true'
         uses: nearform-actions/github-action-notify-twitter@v1
         with:
           message: |


### PR DESCRIPTION
- Prioritize evolution package when it has real changes
- Filter out releases with only dependency updates
- Fallback to other packages if evolution has no changes