### PR TITLE
ci(twitter): use AI to generate release tweets with thread support

### DIFF
--- a/.github/scripts/generate-release-tweet.mjs
+++ b/.github/scripts/generate-release-tweet.mjs
@@ -94,19 +94,41 @@ const generateTweets = async (releaseNotes, releaseUrl, token, model) => {
     parsed.tweets = parsed.tweets.slice(0, MAX_THREAD_LENGTH);
   }
 
-  // Ensure the last tweet contains the release URL
+  // Strip emojis and hashtags the model may have included despite instructions
+  const EMOJI_RE =
+    /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/gu;
+  const HASHTAG_RE = /#\w+/g;
+  for (const [i, tweet] of parsed.tweets.entries()) {
+    parsed.tweets[i] = tweet
+      .replace(EMOJI_RE, "")
+      .replace(HASHTAG_RE, "")
+      .replace(/  +/g, " ")
+      .trim();
+  }
+
+  // Ensure the last tweet ends with the release URL
   if (releaseUrl && parsed.tweets.length > 0) {
-    const last = parsed.tweets[parsed.tweets.length - 1];
-    if (!last.includes(releaseUrl)) {
-      const appended = `${last}\n\n${releaseUrl}`;
+    const lastIndex = parsed.tweets.length - 1;
+    const trimmedLast = parsed.tweets[lastIndex].trimEnd();
+
+    if (!trimmedLast.endsWith(releaseUrl)) {
+      // Remove any existing occurrences of the URL to avoid duplicates
+      const withoutUrl = trimmedLast.split(releaseUrl).join("").trimEnd();
+      const separator = withoutUrl.length > 0 ? "\n\n" : "";
+      const appended = `${withoutUrl}${separator}${releaseUrl}`;
+
       if (appended.length <= MAX_TWEET_LENGTH) {
-        parsed.tweets[parsed.tweets.length - 1] = appended;
+        parsed.tweets[lastIndex] = appended;
       } else {
-        // Trim last tweet to make room for URL
-        const maxText = MAX_TWEET_LENGTH - releaseUrl.length - 3; // 3 for \n\n + …
-        parsed.tweets[parsed.tweets.length - 1] =
-          last.slice(0, maxText) + "…\n\n" + releaseUrl;
+        // Trim last tweet text to make room for URL
+        const maxText =
+          MAX_TWEET_LENGTH - releaseUrl.length - separator.length - 1;
+        const truncatedText =
+          maxText > 0 ? withoutUrl.slice(0, maxText) + "…" : "…";
+        parsed.tweets[lastIndex] = `${truncatedText}${separator}${releaseUrl}`;
       }
+    } else {
+      parsed.tweets[lastIndex] = trimmedLast;
     }
   }
 

--- a/.github/workflows/post-release-to-x.yml
+++ b/.github/workflows/post-release-to-x.yml
@@ -6,6 +6,10 @@ on:
     types: [completed]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  models: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -20,9 +24,9 @@ jobs:
         id: releases
         run: |
           # Fetch @evolution-sdk releases created in the last hour with real changes
-          NOTES=""
           URL=""
           FOUND="false"
+          : > /tmp/release-notes.md
 
           RELEASES=$(gh api /repos/${{ github.repository }}/releases \
             --jq '[.[] | select(.tag_name | startswith("@evolution-sdk/"))]')
@@ -55,7 +59,9 @@ jobs:
 
             if [ -n "$REAL" ]; then
               FOUND="true"
-              NOTES="${NOTES}### ${TAG}\n${BODY}\n\n"
+              echo "### ${TAG}" >> /tmp/release-notes.md
+              echo "$BODY" >> /tmp/release-notes.md
+              echo "" >> /tmp/release-notes.md
               # Prefer the evolution package URL
               if [[ "$TAG" == "@evolution-sdk/evolution@"* ]] || [ -z "$URL" ]; then
                 URL="$RELEASE_URL"
@@ -64,9 +70,6 @@ jobs:
           done
 
           echo "found=$FOUND" >> $GITHUB_OUTPUT
-
-          # Write multi-line notes to file (avoids shell escaping issues)
-          printf '%b' "$NOTES" > /tmp/release-notes.md
           echo "url=$URL" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +88,11 @@ jobs:
             RELEASE_URL="${{ steps.releases.outputs.url }}" \
             GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
             node .github/scripts/generate-release-tweet.mjs)
-          echo "tweets=$RESULT" >> $GITHUB_OUTPUT
+          {
+            echo 'tweets<<EOF'
+            echo "$RESULT"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post thread to X
         if: steps.releases.outputs.found == 'true'
@@ -93,7 +100,6 @@ jobs:
           npm install twitter-api-v2@1
           node -e "
             const { TwitterApi } = require('twitter-api-v2');
-            const fs = require('fs');
 
             const client = new TwitterApi({
               appKey: process.env.TWITTER_API_KEY,


### PR DESCRIPTION
The post-release-to-x workflow used a hardcoded one-liner tweet template with optional carbon-now-cli code images. It couldn't summarize what actually changed or decide whether a thread was warranted.

Replaced the static template with an AI-generated flow: a new script calls GitHub Models (gpt-4o-mini, no extra secrets needed) to read the aggregated release notes and produce 1-4 tweets depending on release significance. The workflow now collects all recent releases with real changes, feeds them to the script, and posts the result as a thread using tweet replies. Dependency-only releases produce no tweet.