### PR TITLE
fix: use Conway maxRefScriptSizePerTx limit 204,800 bytes (200 KiB)

### DIFF
--- a/packages/evolution/src/sdk/builders/TxBuilderImpl.ts
+++ b/packages/evolution/src/sdk/builders/TxBuilderImpl.ts
@@ -203,11 +203,11 @@ export const calculateReferenceScriptFee = (
 
     yield* Effect.logDebug(`[RefScriptFee] Total reference script size: ${totalScriptSize} bytes`)
 
-    if (totalScriptSize > 200_000) {
-      // maxRefScriptSizePerTx from Conway ledger rules (CIP-0069 / CIP-0112)
+    if (totalScriptSize > 204_800) {
+      // maxRefScriptSizePerTx: 200 * 1024 = 204,800 bytes (200 KiB). Hardcoded in Conway era, becomes a protocol parameter in Dijkstra era.
       return yield* Effect.fail(
         new TransactionBuilderError({
-          message: `Total reference script size (${totalScriptSize} bytes) exceeds maximum limit of 200,000 bytes`
+          message: `Total reference script size (${totalScriptSize} bytes) exceeds maximum limit of 204,800 bytes`
         })
       )
     }


### PR DESCRIPTION
### Summary

`calculateReferenceScriptFee` in `TxBuilderImpl.ts` was rejecting transactions whose total reference script size exceeded **200,000** bytes. The Conway-era hard cap is **204,800** bytes (200 × 1024 = 200 KiB). Transactions with total reference script size between 200,001 and 204,800 bytes were incorrectly rejected by the SDK but accepted by the node.

Closes #178

### Root cause

The check used a literal `200_000` instead of the ledger constant `200 * 1024`:

- **Before:** `if (totalScriptSize > 200_000)`
- **After:** `if (totalScriptSize > 204_800)`

Source: Conway ledger `ppMaxRefScriptSizePerTxG = 200 * 1024` (ConwayEraPParams, ADR-009). This becomes a protocol parameter in Dijkstra era (`ppMaxRefScriptSizePerTxL`).

### Changes

- **`packages/evolution/src/sdk/builders/TxBuilderImpl.ts`** (`calculateReferenceScriptFee`):
  - Limit changed from `200_000` to `204_800`.
  - Comment updated to document 200 × 1024 = 204,800 bytes (200 KiB), Conway hardcap, and Dijkstra protocol parameter.
  - Error message updated to say "204,800 bytes".
