### PR TITLE
chore(aiken-uplc): add direnv .envrc for nix flake

### DIFF
--- a/packages/aiken-uplc/.envrc
+++ b/packages/aiken-uplc/.envrc
@@ -1,0 +1,1 @@
+use flake


### PR DESCRIPTION
The aiken-uplc package has a flake.nix but no .envrc, so direnv does not automatically load the Nix shell when entering the directory.

Adds a minimal .envrc with `use flake` so direnv picks up the Nix dev environment automatically.