### PR TITLE
fix(docs): expose NEXT_PUBLIC_BASE_PATH so blueprint sample fetch works on GitHub Pages

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -3,6 +3,7 @@ import { createMDX } from "fumadocs-mdx/next"
 const withMDX = createMDX()
 
 const isCI = !!process.env.GITHUB_ACTIONS
+const basePath = isCI ? '/evolution-sdk' : ''
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
@@ -10,8 +11,11 @@ const config = {
   output: 'export',
   distDir: 'out',
   // when running in CI for GitHub Pages, set basePath/assetPrefix
-  basePath: isCI ? '/evolution-sdk' : '',
-  assetPrefix: isCI ? '/evolution-sdk' : '',
+  basePath,
+  assetPrefix: basePath,
+  env: {
+    NEXT_PUBLIC_BASE_PATH: basePath,
+  },
   trailingSlash: true,
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Problem

The "Load Sample" button on the Blueprint Codegen tool was returning "Failed to load sample blueprint" on the GitHub Pages deployment.

`loadSample()` fetched `${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/sample-blueprint.json`, but `NEXT_PUBLIC_BASE_PATH` was never set, so it always resolved to `/sample-blueprint.json` — a 404 on GitHub Pages (where the site lives under `/evolution-sdk/`).

## Fix

Extract `basePath` into a variable and expose it via `env.NEXT_PUBLIC_BASE_PATH` in `next.config.mjs`. Next.js bakes `env.*` values into the static export at build time, so the correct prefix (`/evolution-sdk`) is now available client-side.

## History

1. Originally: `fetch('/sample-blueprint.json')` — worked locally, broken on GH Pages
2. Commit `2f2a6d5`: hardcoded to `/evolution-sdk/sample-blueprint.json` — worked on GH Pages, broken locally
3. Later refactored to use `NEXT_PUBLIC_BASE_PATH` — correct pattern, but the env var was never injected
4. This PR: actually injects the env var