### PR TITLE
feat(client): add CIP-103 batch transaction signing (signTxs)

### DIFF
--- a/.changeset/cip103-sign-txs.md
+++ b/.changeset/cip103-sign-txs.md
@@ -1,0 +1,9 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Add `signTxs` method to `SigningClient`, `OfflineSignerClient`, and all wallet types for batch transaction signing per CIP-103. For CIP-30 browser wallets, the implementation detects `api.cip103.signTxs`, `api.experimental.signTxs`, or direct `api.signTxs` and falls back to sequential `api.signTx` calls when no batch method is available. Seed and private key wallets delegate to per-transaction signing internally.
+
+- `WalletApi` now accepts optional `cip103`, `experimental`, and direct `signTxs` properties
+- `TransactionSignatureRequest` type exported from `Wallet` module
+- `signTxsWithAutoFetch` aggregates reference inputs across all transactions in a single provider call

--- a/packages/evolution/src/sdk/client/Client.ts
+++ b/packages/evolution/src/sdk/client/Client.ts
@@ -27,6 +27,16 @@ export interface OfflineSignerClientEffect extends AddressClientEffect {
     tx: Parameters<Wallet.SigningWalletEffect["signTx"]>[0],
     context?: Parameters<Wallet.SigningWalletEffect["signTx"]>[1]
   ) => ReturnType<Wallet.SigningWalletEffect["signTx"]>
+  /**
+   * Sign multiple transactions in batch (CIP-103).
+   * Falls back to sequential signTx if the wallet doesn't support batch signing.
+   *
+   * @since 2.2.0
+   */
+  readonly signTxs: (
+    txs: Parameters<Wallet.SigningWalletEffect["signTxs"]>[0],
+    context?: Parameters<Wallet.SigningWalletEffect["signTxs"]>[1]
+  ) => ReturnType<Wallet.SigningWalletEffect["signTxs"]>
   readonly signMessage: Wallet.SigningWalletEffect["signMessage"]
 }
 

--- a/packages/evolution/src/sdk/client/internal/Client.ts
+++ b/packages/evolution/src/sdk/client/internal/Client.ts
@@ -40,6 +40,7 @@ const createOfflineSignerEffect = (wallet: Signing.ResolvedSignerWallet): Offlin
   address: wallet.effect.address.bind(wallet.effect),
   rewardAddress: wallet.effect.rewardAddress.bind(wallet.effect),
   signTx: (txOrHex, context) => Signing.signWithWallet(wallet, txOrHex, context),
+  signTxs: (txs, context) => Signing.signTxsWithWallet(wallet, txs, context),
   signMessage: wallet.effect.signMessage.bind(wallet.effect)
 })
 
@@ -50,6 +51,7 @@ const createOfflineSignerClient = (chain: Chain, wallet: Signing.ResolvedSignerW
     address: () => runEffectPromise(effectInterface.address()),
     rewardAddress: () => runEffectPromise(effectInterface.rewardAddress()),
     signTx: (txOrHex, context) => runEffectPromise(effectInterface.signTx(txOrHex, context)),
+    signTxs: (txs, context) => runEffectPromise(effectInterface.signTxs(txs, context)),
     signMessage: (address, payload) => runEffectPromise(effectInterface.signMessage(address, payload)),
     chain,
     withBlockfrost: (config) => createSigningClient(chain, Providers.blockfrost(config), wallet),
@@ -104,6 +106,7 @@ const createSigningClient = (
     rewardAddress: wallet.effect.rewardAddress,
     signMessage: wallet.effect.signMessage,
     signTx: (txOrHex, context) => Signing.signWithAutoFetch(provider, wallet, txOrHex, context),
+    signTxs: (txs, context) => Signing.signTxsWithAutoFetch(provider, wallet, txs, context),
     getWalletUtxos: () => Effect.flatMap(wallet.effect.address(), (address) => provider.effect.getUtxos(address)),
     getWalletDelegation: () =>
       Effect.flatMap(wallet.effect.rewardAddress(), (rewardAddress) => {
@@ -121,6 +124,7 @@ const createSigningClient = (
     rewardAddress: () => runEffectPromise(effectInterface.rewardAddress()),
     signMessage: (address, payload) => runEffectPromise(effectInterface.signMessage(address, payload)),
     signTx: (txOrHex, context) => runEffectPromise(effectInterface.signTx(txOrHex, context)),
+    signTxs: (txs, context) => runEffectPromise(effectInterface.signTxs(txs, context)),
     getWalletUtxos: () => runEffectPromise(effectInterface.getWalletUtxos()),
     getWalletDelegation: () => runEffectPromise(effectInterface.getWalletDelegation()),
     chain,

--- a/packages/evolution/src/sdk/client/internal/Signing.ts
+++ b/packages/evolution/src/sdk/client/internal/Signing.ts
@@ -191,6 +191,62 @@ export const signWithWallet = (
     ? wallet.effect.signTx(txOrHex, context ? { utxos: context.utxos } : undefined)
     : wallet.effect.signTx(txOrHex, context)
 
+export const signTxsWithWallet = (
+  wallet: ResolvedSignerWallet,
+  txs: ReadonlyArray<Parameters<Wallet.SigningWalletEffect["signTx"]>[0]>,
+  context?: Parameters<Wallet.SigningWalletEffect["signTx"]>[1]
+): Effect.Effect<ReadonlyArray<TransactionWitnessSet.TransactionWitnessSet>, Wallet.WalletError> =>
+  wallet.type === "api"
+    ? wallet.effect.signTxs(txs, context ? { utxos: context.utxos } : undefined)
+    : wallet.effect.signTxs(txs, context)
+
+export const signTxsWithAutoFetch = (
+  provider: Provider.Provider,
+  wallet: ResolvedSignerWallet,
+  txs: ReadonlyArray<Parameters<Wallet.SigningWalletEffect["signTx"]>[0]>,
+  context?: Parameters<Wallet.SigningWalletEffect["signTx"]>[1]
+): Effect.Effect<ReadonlyArray<TransactionWitnessSet.TransactionWitnessSet>, Wallet.WalletError> =>
+  Effect.gen(function* () {
+    if (wallet.type === "api") {
+      return yield* signTxsWithWallet(wallet, txs, context)
+    }
+
+    if (context?.referenceUtxos && context.referenceUtxos.length > 0) {
+      return yield* wallet.effect.signTxs(txs, context)
+    }
+
+    // Collect all reference inputs across all transactions and fetch them once
+    const allRefInputs: Array<TransactionBody.TransactionBody["inputs"][number]> = []
+    for (const txOrHex of txs) {
+      const tx =
+        typeof txOrHex === "string"
+          ? yield* ParseResult.decodeUnknownEither(Transaction.FromCBORHex())(txOrHex).pipe(
+              Effect.mapError(
+                (cause) => new Wallet.WalletError({ message: `Failed to decode transaction: ${cause}`, cause })
+              )
+            )
+          : txOrHex
+      if (tx.body.referenceInputs) {
+        allRefInputs.push(...tx.body.referenceInputs)
+      }
+    }
+
+    let referenceUtxos: ReadonlyArray<CoreUTxO.UTxO> = []
+    if (allRefInputs.length > 0) {
+      referenceUtxos = yield* provider.effect.getUtxosByOutRef(allRefInputs).pipe(
+        Effect.mapError(
+          (error) =>
+            new Wallet.WalletError({
+              message: `Failed to fetch reference UTxOs: ${error.message}`,
+              cause: error
+            })
+        )
+      )
+    }
+
+    return yield* wallet.effect.signTxs(txs, { ...context, referenceUtxos })
+  })
+
 export const signWithAutoFetch = (
   provider: Provider.Provider,
   wallet: ResolvedSignerWallet,
@@ -295,6 +351,7 @@ export const makeSigningWalletEffect = (
 
         return witnesses.length > 0 ? TransactionWitnessSet.fromVKeyWitnesses(witnesses) : TransactionWitnessSet.empty()
       }),
+    signTxs: (txs, context) => Effect.all(txs.map((tx) => effectInterface.signTx(tx, context))),
     signMessage: (address, payload) =>
       Effect.gen(function* () {
         const derivation = yield* derivationEffect
@@ -313,6 +370,7 @@ export const makeSigningWalletEffect = (
     address: () => runEffectPromise(effectInterface.address()),
     rewardAddress: () => runEffectPromise(effectInterface.rewardAddress()),
     signTx: (txOrHex, context) => runEffectPromise(effectInterface.signTx(txOrHex, context)),
+    signTxs: (txs, context) => runEffectPromise(effectInterface.signTxs(txs, context)),
     signMessage: (address, payload) => runEffectPromise(effectInterface.signMessage(address, payload)),
     effect: effectInterface
   }

--- a/packages/evolution/src/sdk/client/internal/Signing.ts
+++ b/packages/evolution/src/sdk/client/internal/Signing.ts
@@ -216,6 +216,7 @@ export const signTxsWithAutoFetch = (
     }
 
     // Collect all reference inputs across all transactions and fetch them once
+    const seen = new Set<string>()
     const allRefInputs: Array<TransactionBody.TransactionBody["inputs"][number]> = []
     for (const txOrHex of txs) {
       const tx =
@@ -227,7 +228,13 @@ export const signTxsWithAutoFetch = (
             )
           : txOrHex
       if (tx.body.referenceInputs) {
-        allRefInputs.push(...tx.body.referenceInputs)
+        for (const ref of tx.body.referenceInputs) {
+          const key = `${ref.transactionId}#${ref.index}`
+          if (!seen.has(key)) {
+            seen.add(key)
+            allRefInputs.push(ref)
+          }
+        }
       }
     }
 

--- a/packages/evolution/src/sdk/client/internal/Wallets.ts
+++ b/packages/evolution/src/sdk/client/internal/Wallets.ts
@@ -219,6 +219,52 @@ export const cip30Wallet =
         })
         return { payload, signature: result.signature }
       }),
+    signTxs: (txs: ReadonlyArray<Transaction.Transaction | string>, _context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO> }) =>
+      Effect.gen(function* () {
+        const cborHexes = txs.map((txOrHex) => typeof txOrHex === "string" ? txOrHex : Transaction.toCBORHex(txOrHex))
+        const requests = cborHexes.map((cbor) => ({ cbor, partialSign: true }))
+
+        // Try CIP-103 standard namespace, then experimental, then direct, then fallback
+        const signTxsFn =
+          api.cip103?.signTxs?.bind(api.cip103) ??
+          api.experimental?.signTxs?.bind(api.experimental) ??
+          api.signTxs?.bind(api)
+
+        let witnessHexes: ReadonlyArray<string>
+        if (signTxsFn) {
+          witnessHexes = yield* Effect.tryPromise({
+            try: () => signTxsFn(requests),
+            catch: (cause) =>
+              new Wallet.WalletError({
+                message: `Failed to batch sign transactions: ${(cause as Error).message ?? cause}`,
+                cause
+              })
+          })
+        } else {
+          // Fallback: sequential signing
+          const results: Array<string> = []
+          for (const cbor of cborHexes) {
+            const witness = yield* Effect.tryPromise({
+              try: () => api.signTx(cbor, true),
+              catch: (cause) =>
+                new Wallet.WalletError({
+                  message: `Failed to sign transaction: ${(cause as Error).message ?? cause}`,
+                  cause
+                })
+            })
+            results.push(witness)
+          }
+          witnessHexes = results
+        }
+
+        return yield* Effect.all(
+          witnessHexes.map((hex) =>
+            ParseResult.decodeUnknownEither(TransactionWitnessSet.FromCBORHex())(hex).pipe(
+              Effect.mapError((cause) => new Wallet.WalletError({ message: `Failed to decode witness set: ${cause}`, cause }))
+            )
+          )
+        )
+      }),
     submitTx: (txOrHex: Transaction.Transaction | string) =>
       Effect.gen(function* () {
         const cbor = typeof txOrHex === "string" ? txOrHex : Transaction.toCBORHex(txOrHex)
@@ -236,6 +282,7 @@ export const cip30Wallet =
     address: () => runEffectPromise(effectInterface.address()),
     rewardAddress: () => runEffectPromise(effectInterface.rewardAddress()),
     signTx: (txOrHex, context) => runEffectPromise(effectInterface.signTx(txOrHex, context)),
+    signTxs: (txs, context) => runEffectPromise(effectInterface.signTxs(txs, context)),
     signMessage: (address, payload) => runEffectPromise(effectInterface.signMessage(address, payload)),
     submitTx: (txOrHex) => runEffectPromise(effectInterface.submitTx(txOrHex)),
     effect: effectInterface

--- a/packages/evolution/src/sdk/wallet/Wallet.ts
+++ b/packages/evolution/src/sdk/wallet/Wallet.ts
@@ -90,6 +90,16 @@ export interface SigningWalletEffect extends ReadOnlyWalletEffect {
     tx: Transaction.Transaction | string,
     context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO>; referenceUtxos?: ReadonlyArray<CoreUTxO.UTxO> }
   ) => Effect.Effect<TransactionWitnessSet.TransactionWitnessSet, WalletError>
+  /**
+   * Sign multiple transactions in batch (CIP-103).
+   * Falls back to sequential signTx if the wallet doesn't support batch signing.
+   *
+   * @since 2.2.0
+   */
+  readonly signTxs: (
+    txs: ReadonlyArray<Transaction.Transaction | string>,
+    context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO>; referenceUtxos?: ReadonlyArray<CoreUTxO.UTxO> }
+  ) => Effect.Effect<ReadonlyArray<TransactionWitnessSet.TransactionWitnessSet>, WalletError>
   readonly signMessage: (
     address: CoreAddress.Address | RewardAddress.RewardAddress,
     payload: Payload
@@ -103,7 +113,11 @@ export interface SigningWalletEffect extends ReadOnlyWalletEffect {
  * @since 2.0.0
  * @category model
  */
-export interface SigningWallet extends EffectToPromiseAPI<SigningWalletEffect> {
+export interface SigningWallet extends EffectToPromiseAPI<Omit<SigningWalletEffect, "signTxs">> {
+  readonly signTxs: (
+    txs: ReadonlyArray<Transaction.Transaction | string>,
+    context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO>; referenceUtxos?: ReadonlyArray<CoreUTxO.UTxO> }
+  ) => Promise<ReadonlyArray<TransactionWitnessSet.TransactionWitnessSet>>
   readonly effect: SigningWalletEffect
   readonly type: "signing"
 }
@@ -115,6 +129,17 @@ export interface SigningWallet extends EffectToPromiseAPI<SigningWalletEffect> {
  * @since 2.0.0
  * @category model
  */
+/**
+ * CIP-103 transaction signature request for batch signing.
+ *
+ * @since 2.2.0
+ * @category model
+ */
+export interface TransactionSignatureRequest {
+  readonly cbor: string
+  readonly partialSign: boolean
+}
+
 export interface WalletApi {
   getUsedAddresses(): Promise<ReadonlyArray<string>>
   getUnusedAddresses(): Promise<ReadonlyArray<string>>
@@ -123,6 +148,16 @@ export interface WalletApi {
   signTx(txCborHex: string, partialSign: boolean): Promise<string>
   signData(addressHex: string, payload: Payload): Promise<SignedMessage>
   submitTx(txCborHex: string): Promise<string>
+  /** CIP-103 standard namespace */
+  cip103?: {
+    signTxs(requests: ReadonlyArray<TransactionSignatureRequest>): Promise<ReadonlyArray<string>>
+  }
+  /** Experimental namespace (e.g. Eternl) */
+  experimental?: {
+    signTxs?(requests: ReadonlyArray<TransactionSignatureRequest>): Promise<ReadonlyArray<string>>
+  }
+  /** Direct signTxs (some wallets) */
+  signTxs?(requests: ReadonlyArray<TransactionSignatureRequest>): Promise<ReadonlyArray<string>>
 }
 
 /**
@@ -138,6 +173,16 @@ export interface ApiWalletEffect extends ReadOnlyWalletEffect {
     tx: Transaction.Transaction | string,
     context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO> }
   ) => Effect.Effect<TransactionWitnessSet.TransactionWitnessSet, WalletError>
+  /**
+   * Sign multiple transactions in batch (CIP-103).
+   * Falls back to sequential signTx if the wallet doesn't support batch signing.
+   *
+   * @since 2.2.0
+   */
+  readonly signTxs: (
+    txs: ReadonlyArray<Transaction.Transaction | string>,
+    context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO> }
+  ) => Effect.Effect<ReadonlyArray<TransactionWitnessSet.TransactionWitnessSet>, WalletError>
   readonly signMessage: (
     address: CoreAddress.Address | RewardAddress.RewardAddress,
     payload: Payload
@@ -159,7 +204,11 @@ export interface ApiWalletEffect extends ReadOnlyWalletEffect {
  * @since 2.0.0
  * @category model
  */
-export interface ApiWallet extends EffectToPromiseAPI<ApiWalletEffect> {
+export interface ApiWallet extends EffectToPromiseAPI<Omit<ApiWalletEffect, "signTxs">> {
+  readonly signTxs: (
+    txs: ReadonlyArray<Transaction.Transaction | string>,
+    context?: { utxos?: ReadonlyArray<CoreUTxO.UTxO> }
+  ) => Promise<ReadonlyArray<TransactionWitnessSet.TransactionWitnessSet>>
   readonly effect: ApiWalletEffect
   readonly api: WalletApi
   readonly type: "api"

--- a/packages/evolution/test/Client.SignTxs.test.ts
+++ b/packages/evolution/test/Client.SignTxs.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+import { preprod } from "../src/sdk/client/Chain.js"
+import { cip30Wallet } from "../src/sdk/client/internal/Wallets.js"
+import type * as Wallet from "../src/sdk/wallet/Wallet.js"
+import * as TransactionWitnessSet from "../src/TransactionWitnessSet.js"
+
+const emptyWitnessHex = TransactionWitnessSet.toCBORHex(TransactionWitnessSet.empty())
+
+// Minimal mock transaction CBOR (enough to pass through signTx without decoding)
+const fakeTxCbor1 = "84a400818258200000000000000000000000000000000000000000000000000000000000000000000182a200583900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a001e8480a200583900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a001e8480021a00028a00031a00d59f80a100818258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f5f6"
+const fakeTxCbor2 = "84a400818258200000000000000000000000000000000000000000000000000000000000000001000182a200583900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a001e8480a200583900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001a001e8480021a00028a00031a00d59f80a100818258200000000000000000000000000000000000000000000000000000000000000000584000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f5f6"
+
+// Testnet address hex (network id 0)
+const testnetAddressHex =
+  "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+const makeBaseMockApi = (): Wallet.WalletApi => ({
+  getUsedAddresses: () => Promise.resolve([testnetAddressHex]),
+  getUnusedAddresses: () => Promise.resolve([]),
+  getRewardAddresses: () => Promise.resolve([]),
+  getUtxos: () => Promise.resolve([]),
+  signTx: () => Promise.resolve(emptyWitnessHex),
+  signData: () => Promise.resolve({ payload: "", signature: "" }),
+  submitTx: () => Promise.resolve("0000000000000000000000000000000000000000000000000000000000000000")
+})
+
+describe("Client.signTxs (CIP-103)", () => {
+  it("uses cip103.signTxs when available", async () => {
+    const calls: Array<string> = []
+    const mockApi: Wallet.WalletApi = {
+      ...makeBaseMockApi(),
+      cip103: {
+        signTxs: (requests) => {
+          calls.push("cip103")
+          return Promise.resolve(requests.map(() => emptyWitnessHex))
+        }
+      },
+      experimental: {
+        signTxs: (requests) => {
+          calls.push("experimental")
+          return Promise.resolve(requests.map(() => emptyWitnessHex))
+        }
+      }
+    }
+
+    const wallet = cip30Wallet(mockApi)(preprod)
+    const results = await wallet.signTxs([fakeTxCbor1, fakeTxCbor2])
+
+    expect(calls).toEqual(["cip103"])
+    expect(results).toHaveLength(2)
+  })
+
+  it("falls back to experimental.signTxs when cip103 is not available", async () => {
+    const calls: Array<string> = []
+    const mockApi: Wallet.WalletApi = {
+      ...makeBaseMockApi(),
+      experimental: {
+        signTxs: (requests) => {
+          calls.push("experimental")
+          return Promise.resolve(requests.map(() => emptyWitnessHex))
+        }
+      }
+    }
+
+    const wallet = cip30Wallet(mockApi)(preprod)
+    const results = await wallet.signTxs([fakeTxCbor1, fakeTxCbor2])
+
+    expect(calls).toEqual(["experimental"])
+    expect(results).toHaveLength(2)
+  })
+
+  it("falls back to direct signTxs when no namespace is available", async () => {
+    const calls: Array<string> = []
+    const mockApi: Wallet.WalletApi = {
+      ...makeBaseMockApi(),
+      signTxs: (requests) => {
+        calls.push("direct")
+        return Promise.resolve(requests.map(() => emptyWitnessHex))
+      }
+    }
+
+    const wallet = cip30Wallet(mockApi)(preprod)
+    const results = await wallet.signTxs([fakeTxCbor1, fakeTxCbor2])
+
+    expect(calls).toEqual(["direct"])
+    expect(results).toHaveLength(2)
+  })
+
+  it("falls back to sequential signTx when no batch method exists", async () => {
+    const signedTxs: Array<string> = []
+    const mockApi: Wallet.WalletApi = {
+      ...makeBaseMockApi(),
+      signTx: (txCborHex, _partialSign) => {
+        signedTxs.push(txCborHex)
+        return Promise.resolve(emptyWitnessHex)
+      }
+    }
+
+    const wallet = cip30Wallet(mockApi)(preprod)
+    const results = await wallet.signTxs([fakeTxCbor1, fakeTxCbor2])
+
+    expect(signedTxs).toEqual([fakeTxCbor1, fakeTxCbor2])
+    expect(results).toHaveLength(2)
+  })
+
+  it("passes correct TransactionSignatureRequest format to batch methods", async () => {
+    let capturedRequests: ReadonlyArray<Wallet.TransactionSignatureRequest> = []
+    const mockApi: Wallet.WalletApi = {
+      ...makeBaseMockApi(),
+      cip103: {
+        signTxs: (requests) => {
+          capturedRequests = requests
+          return Promise.resolve(requests.map(() => emptyWitnessHex))
+        }
+      }
+    }
+
+    const wallet = cip30Wallet(mockApi)(preprod)
+    await wallet.signTxs([fakeTxCbor1, fakeTxCbor2])
+
+    expect(capturedRequests).toHaveLength(2)
+    expect(capturedRequests[0]).toEqual({ cbor: fakeTxCbor1, partialSign: true })
+    expect(capturedRequests[1]).toEqual({ cbor: fakeTxCbor2, partialSign: true })
+  })
+
+  it("returns decoded TransactionWitnessSet instances", async () => {
+    const mockApi: Wallet.WalletApi = {
+      ...makeBaseMockApi(),
+      cip103: {
+        signTxs: (requests) => Promise.resolve(requests.map(() => emptyWitnessHex))
+      }
+    }
+
+    const wallet = cip30Wallet(mockApi)(preprod)
+    const results = await wallet.signTxs([fakeTxCbor1])
+
+    expect(results).toHaveLength(1)
+    expect(TransactionWitnessSet.toCBORHex(results[0])).toBe(emptyWitnessHex)
+  })
+
+  it.effect("works through seed wallet signTxs (sequential delegation)", () =>
+    Effect.gen(function* () {
+      const { Client, preprod } = yield* Effect.promise(() => import("../src/index.js"))
+
+      const seedPhrase =
+        "zebra short room flavor rival capital fortune hip profit trust melody office depend adapt visa cycle february link tornado whisper physical kiwi film voyage"
+
+      const offlineSigner = Client.make(preprod).withSeed({ mnemonic: seedPhrase })
+
+      // signTxs on a seed wallet delegates to sequential signTx calls
+      // We can't easily test with real txs here, but we verify the method exists and is callable
+      expect(typeof offlineSigner.signTxs).toBe("function")
+    })
+  )
+})


### PR DESCRIPTION
The SDK only supports signing one transaction at a time. For chained transactions this means multiple wallet popups in browser wallets — poor UX. CIP-103 defines a batch `signTxs` method that wallets like Eternl already support under `api.experimental.signTxs`.

Adds `signTxs` to `SigningClient`, `OfflineSignerClient`, and all wallet types. For CIP-30 wallets the implementation probes `api.cip103.signTxs`, `api.experimental.signTxs`, and direct `api.signTxs` in priority order, falling back to sequential `api.signTx` when no batch method exists. Seed and private key wallets delegate to per-transaction signing. `signTxsWithAutoFetch` aggregates reference inputs across all transactions into a single provider call.

Closes #233