### PR TITLE
feat(Address): add fromSeed for synchronous address derivation

### DIFF
--- a/.changeset/address-from-seed.md
+++ b/.changeset/address-from-seed.md
@@ -1,0 +1,10 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Add `Address.fromSeed()` for synchronous address derivation from a BIP-39 seed phrase. This enables deriving addresses without constructing a `Client` or `Chain` instance — useful for devnet genesis funding where the address must be known before the cluster starts.
+
+The `Derivation` module now accepts a numeric `networkId` (0 = testnet, 1 = mainnet) instead of a `network` string (`"Mainnet" | "Testnet" | "Custom"`). The default changed from mainnet (1) to testnet (0). If you call `walletFromSeed`, `addressFromSeed`, `walletFromBip32`, or `walletFromPrivateKey` with the old `network` option, replace it with `networkId`:
+
+- `network: "Mainnet"` → `networkId: 1`
+- `network: "Testnet"` or `network: "Custom"` → `networkId: 0` (or omit, since 0 is the default)

--- a/docs/content/docs/devnet/configuration.mdx
+++ b/docs/content/docs/devnet/configuration.mdx
@@ -27,19 +27,13 @@ import {
   Config } from "@evolution-sdk/devnet"
 import { Address,
   TransactionHash,
-  preprod,
-  Client,
 } from "@evolution-sdk/evolution"
 
-// Create a client to generate an address (preprod has id: 0, producing testnet-format addresses)
-const client = Client.make(preprod)
-  .withSeed({
-    mnemonic: "your twenty-four word mnemonic phrase here",
-    accountIndex: 0
-  })
-
-// Get the address
-const address = await client.address()
+// Derive address from seed (synchronous, no network required)
+const address = Address.fromSeed("your twenty-four word mnemonic phrase here", {
+  accountIndex: 0,
+  networkId: 0 // testnet address format
+})
 
 // Convert to hex for genesis configuration
 const addressHex = Address.toHex(address)
@@ -78,24 +72,17 @@ import {
   Config } from "@evolution-sdk/devnet"
 import { Address,
   TransactionHash,
-  preprod,
-  Client,
 } from "@evolution-sdk/evolution"
 
-const client1 = Client.make(preprod)
-  .withSeed({
-    mnemonic: "your mnemonic here",
-    accountIndex: 0
-  })
+const address1 = Address.toHex(Address.fromSeed("your mnemonic here", {
+  accountIndex: 0,
+  networkId: 0
+}))
 
-const client2 = Client.make(preprod)
-  .withSeed({
-    mnemonic: "your mnemonic here",
-    accountIndex: 1 // Different account index = different address
-  })
-
-const address1 = Address.toHex(await client1.address())
-const address2 = Address.toHex(await client2.address())
+const address2 = Address.toHex(Address.fromSeed("your mnemonic here", {
+  accountIndex: 1, // Different account index = different address
+  networkId: 0
+}))
 
 const genesisConfig = {
   ...Config.DEFAULT_SHELLEY_GENESIS,
@@ -314,25 +301,18 @@ import {
   Genesis } from "@evolution-sdk/devnet"
 import { Address,
   TransactionHash,
-  preprod,
-  Client,
 } from "@evolution-sdk/evolution"
 
-// Generate funded addresses
-const wallet1 = Client.make(preprod)
-  .withSeed({
-    mnemonic: "test wallet one mnemonic here",
-    accountIndex: 0
-  })
+// Generate funded addresses (synchronous, no network required)
+const addr1 = Address.toHex(Address.fromSeed("test wallet one mnemonic here", {
+  accountIndex: 0,
+  networkId: 0
+}))
 
-const wallet2 = Client.make(preprod)
-  .withSeed({
-    mnemonic: "test wallet two mnemonic here",
-    accountIndex: 0
-  })
-
-const addr1 = Address.toHex(await wallet1.address())
-const addr2 = Address.toHex(await wallet2.address())
+const addr2 = Address.toHex(Address.fromSeed("test wallet two mnemonic here", {
+  accountIndex: 0,
+  networkId: 0
+}))
 
 // Custom genesis configuration
 const genesisConfig = {
@@ -471,6 +451,6 @@ With custom genesis configuration, you can now:
 
 **Protocol parameter validation**: Some parameter combinations are invalid (e.g., `lovelacePerUTxOWord` too low in Alonzo genesis). Check cardano-node logs if startup fails.
 
-**Client chain parameter**: Use `chain: preprod` (or `Cluster.getChain(cluster)` once the cluster is running) to create testnet-format addresses (`addr_test...`).
+**Address network**: Use `networkId: 0` in `Address.fromSeed()` for testnet-format addresses (`addr_test...`), or use `Cluster.getChain(cluster)` with `Client.make()` once the cluster is running.
 
 **Excessive funds**: While genesis supports arbitrary amounts, extremely large values may cause numeric overflow in some calculations. Stay under 45B ADA (total supply) per address.

--- a/docs/content/docs/devnet/index.mdx
+++ b/docs/content/docs/devnet/index.mdx
@@ -36,6 +36,16 @@ Traditional testnet development introduces friction: unpredictable faucet availa
 - **Offline Testing**: No internet required once Docker images are pulled
 - **Reproducible State**: Deterministic genesis configuration for consistent test results
 
+### What about Yaci DevKit?
+
+Yaci DevKit is a standalone CLI tool for running a local Cardano network. It includes a web-based block explorer, Blockfrost-compatible REST APIs, and a 3-node cluster mode for rollback simulation.
+
+DevNet takes a different approach — it's a library, not a service. Genesis configuration, cluster lifecycle, and UTxO queries are TypeScript code inside your project. There's no separate tool to install or manage, and genesis UTxOs are deterministic and pre-computable from your config without querying the chain.
+
+The tradeoff: Yaci DevKit gives you visual tooling and broader SDK compatibility out of the box. DevNet gives you a code-first workflow where your local blockchain lives inside your test suite. Both run standard cardano-node instances, so blockchain behavior is identical.
+
+See [Configuration](/docs/devnet/configuration) for genesis-as-code examples and [Integration](/docs/devnet/integration) for a complete test workflow from cluster start to confirmed transaction.
+
 ## How Devnet Works
 
 Devnet orchestrates three Docker containers:

--- a/docs/content/docs/devnet/integration.mdx
+++ b/docs/content/docs/devnet/integration.mdx
@@ -34,21 +34,17 @@ import {
 import { Address,
   Assets,
   TransactionHash,
-  preprod,
   Client,
 } from "@evolution-sdk/evolution"
 
 const MNEMONIC = "your twenty-four word mnemonic phrase here"
 
 async function completeWorkflow() {
-  // Step 1: Generate sender address
-  const wallet = Client.make(preprod)
-  .withSeed({ mnemonic: MNEMONIC, accountIndex: 0 })
-
-  const senderAddress = await wallet.address()
+  // Step 1: Derive sender address (synchronous, no network required)
+  const senderAddress = Address.fromSeed(MNEMONIC, { accountIndex: 0, networkId: 0 })
   const senderAddressHex = Address.toHex(senderAddress)
 
-  console.log("Sender address:", senderAddress)
+  console.log("Sender address:", Address.toBech32(senderAddress))
 
   // Step 2: Create genesis configuration with funded address
   const genesisConfig = {
@@ -77,7 +73,7 @@ async function completeWorkflow() {
   console.log("Devnet started with Kupo and Ogmios")
 
   // Step 4: Create client connected to devnet
-  const client = Client.make(preprod)
+  const client = Client.make(Cluster.getChain(cluster))
   .withKupmios({ kupoUrl: "http://localhost:1442", ogmiosUrl: "http://localhost:1337" })
   .withSeed({ mnemonic: MNEMONIC, accountIndex: 0 })
 
@@ -172,7 +168,6 @@ import {
 import { Address,
   Assets,
   TransactionHash,
-  preprod,
   Client,
 } from "@evolution-sdk/evolution"
 
@@ -194,7 +189,7 @@ await Cluster.start(cluster)
 await new Promise((resolve) => setTimeout(resolve, 6000))
 
 // Provider-only client (no wallet configured)
-const providerClient = Client.make(preprod)
+const providerClient = Client.make(Cluster.getChain(cluster))
   .withKupmios({ kupoUrl: "http://localhost:1442", ogmiosUrl: "http://localhost:1337" })
 
 // Query any address on the devnet
@@ -232,7 +227,6 @@ import {
   Address,
   Assets,
   TransactionHash,
-  preprod,
   Client,
 } from "@evolution-sdk/evolution"
 
@@ -245,10 +239,7 @@ describe("Transaction Tests", () => {
     const mnemonic =
       "test test test test test test test test test test test test test test test test test test test test test test test sauce"
 
-    const wallet = Client.make(preprod)
-  .withSeed({ mnemonic, accountIndex: 0 })
-
-    const addressHex = Address.toHex(await wallet.address())
+    const addressHex = Address.toHex(Address.fromSeed(mnemonic, { accountIndex: 0, networkId: 0 }))
 
     const genesisConfig = {
       ...Config.DEFAULT_SHELLEY_GENESIS,
@@ -268,7 +259,7 @@ describe("Transaction Tests", () => {
     await Cluster.start(cluster)
     await new Promise((resolve) => setTimeout(resolve, 8000))
 
-    client = Client.make(preprod)
+    client = Client.make(Cluster.getChain(cluster))
   .withKupmios({ kupoUrl: "http://localhost:1442", ogmiosUrl: "http://localhost:1337" })
   .withSeed({ mnemonic, accountIndex: 0 })
   }, 180_000) // Extended timeout for cluster startup
@@ -335,21 +326,13 @@ import {
 import { Address,
   Assets,
   TransactionHash,
-  preprod,
   Client,
 } from "@evolution-sdk/evolution"
 
 async function multiWalletExample() {
-  // Create two wallets
-  const wallet1 = Client.make(preprod)
-  .withSeed({ mnemonic: "wallet one mnemonic here", accountIndex: 0 })
-
-  const wallet2 = Client.make(preprod)
-  .withSeed({ mnemonic: "wallet two mnemonic here", accountIndex: 0 })
-
-  // Get addresses as hex for genesis config
-  const addr1Hex = Address.toHex(await wallet1.address())
-  const addr2Hex = Address.toHex(await wallet2.address())
+  // Derive addresses for genesis funding (synchronous)
+  const addr1Hex = Address.toHex(Address.fromSeed("wallet one mnemonic here", { accountIndex: 0, networkId: 0 }))
+  const addr2Hex = Address.toHex(Address.fromSeed("wallet two mnemonic here", { accountIndex: 0, networkId: 0 }))
 
   // Fund both in genesis
   const genesisConfig = {
@@ -373,16 +356,16 @@ async function multiWalletExample() {
   await new Promise((resolve) => setTimeout(resolve, 8000))
 
   // Create connected clients for both wallets
-  const client1 = Client.make(preprod)
+  const client1 = Client.make(Cluster.getChain(cluster))
   .withKupmios({ kupoUrl: "http://localhost:1442", ogmiosUrl: "http://localhost:1337" })
   .withSeed({ mnemonic: "wallet one mnemonic here", accountIndex: 0 })
 
-  const client2 = Client.make(preprod)
+  const client2 = Client.make(Cluster.getChain(cluster))
   .withKupmios({ kupoUrl: "http://localhost:1442", ogmiosUrl: "http://localhost:1337" })
   .withSeed({ mnemonic: "wallet two mnemonic here", accountIndex: 0 })
 
   // Wallet 1 sends to Wallet 2
-  const wallet2Address = await wallet2.address()
+  const wallet2Address = await client2.address()
   const signBuilder = await client1
     .newTx()
     .payToAddress({

--- a/packages/evolution/src/Address.ts
+++ b/packages/evolution/src/Address.ts
@@ -11,6 +11,7 @@ import * as Credential from "./Credential.js"
 import * as KeyHash from "./KeyHash.js"
 import * as NetworkId from "./NetworkId.js"
 import * as ScriptHash from "./ScriptHash.js"
+import { addressFromSeed as _addressFromSeed } from "./sdk/wallet/Derivation.js"
 
 /**
  * @since 2.0.0
@@ -228,6 +229,36 @@ export const fromHex = Schema.decodeSync(FromHex)
 export const toHex = Schema.encodeSync(FromHex)
 export const fromBytes = Schema.decodeSync(FromBytes)
 export const toBytes = Schema.encodeSync(FromBytes)
+
+/**
+ * Derive an address from a BIP-39 seed phrase.
+ *
+ * Pure, synchronous key derivation — no network access or running cluster required.
+ * Useful for generating addresses before a devnet cluster starts (e.g. for genesis funding).
+ *
+ * @since 2.1.0
+ * @category Functions
+ *
+ * @example
+ * ```typescript
+ * import * as Address from "@evolution-sdk/evolution/Address"
+ *
+ * const address = Address.fromSeed("your twenty-four word mnemonic ...", {
+ *   accountIndex: 0,
+ *   networkId: 0 // 0 = testnet, 1 = mainnet
+ * })
+ * const hex = Address.toHex(address)
+ * ```
+ */
+export const fromSeed = (
+  seed: string,
+  options: {
+    password?: string
+    addressType?: "Base" | "Enterprise"
+    accountIndex?: number
+    networkId?: number
+  } = {}
+): Address => _addressFromSeed(seed, options).address
 
 /**
  * FastCheck arbitrary generator for testing

--- a/packages/evolution/src/sdk/client/internal/Wallets.ts
+++ b/packages/evolution/src/sdk/client/internal/Wallets.ts
@@ -107,14 +107,13 @@ export const readOnlyWallet =
 export const seedWallet =
   (config: SeedWalletConfig) =>
   (chain: Chain): Wallet.SigningWallet => {
-    const network: Wallet.Network = chain.id === 1 ? "Mainnet" : "Testnet"
     const derivationEffect = Derivation.walletFromSeed(config.mnemonic, {
       addressType: config.addressType ?? "Base",
       accountIndex: config.accountIndex ?? 0,
       paymentIndex: config.paymentIndex ?? 0,
       stakeIndex: config.stakeIndex ?? 0,
       password: config.password,
-      network
+      networkId: chain.id
     }).pipe(Effect.mapError((cause) => new Wallet.WalletError({ message: cause.message, cause })))
     return Signing.makeSigningWalletEffect(derivationEffect)
   }
@@ -129,11 +128,10 @@ export const seedWallet =
 export const privateKeyWallet =
   (config: PrivateKeyWalletConfig) =>
   (chain: Chain): Wallet.SigningWallet => {
-    const network: Wallet.Network = chain.id === 1 ? "Mainnet" : "Testnet"
     const derivationEffect = Derivation.walletFromPrivateKey(config.paymentKey, {
       stakeKeyBech32: config.stakeKey,
       addressType: config.addressType ?? (config.stakeKey ? "Base" : "Enterprise"),
-      network
+      networkId: chain.id
     }).pipe(Effect.mapError((cause) => new Wallet.WalletError({ message: cause.message, cause })))
     return Signing.makeSigningWalletEffect(derivationEffect)
   }

--- a/packages/evolution/src/sdk/wallet/Derivation.ts
+++ b/packages/evolution/src/sdk/wallet/Derivation.ts
@@ -43,11 +43,11 @@ export const walletFromSeed = (
     accountIndex?: number
     paymentIndex?: number
     stakeIndex?: number
-    network?: "Mainnet" | "Testnet" | "Custom"
+    networkId?: number
   } = {}
 ): Effect.Effect<SeedDerivationResult, DerivationError | Bip32PrivateKey.Bip32PrivateKeyError> => {
   return Effect.gen(function* () {
-    const { accountIndex = 0, addressType = "Base", network = "Mainnet", paymentIndex = 0, stakeIndex = 0 } = options
+    const { accountIndex = 0, addressType = "Base", networkId = 0, paymentIndex = 0, stakeIndex = 0 } = options
     const entropy = yield* Effect.try({
       try: () => mnemonicToEntropy(seed, English),
       catch: (cause) => new DerivationError({ message: "Invalid seed phrase", cause })
@@ -66,7 +66,6 @@ export const walletFromSeed = (
 
     const paymentKeyHash = KeyHash.fromPrivateKey(paymentKey)
     const stakeKeyHash = KeyHash.fromPrivateKey(stakeKey)
-    const networkId = network === "Mainnet" ? 1 : 0
 
     const address: CoreAddress.Address =
       addressType === "Base"
@@ -147,10 +146,10 @@ export function addressFromSeed(
     password?: string
     addressType?: "Base" | "Enterprise"
     accountIndex?: number
-    network?: "Mainnet" | "Testnet" | "Custom"
+    networkId?: number
   } = {}
 ): { address: CoreAddress.Address; rewardAddress: CoreRewardAddress.RewardAddress | undefined } {
-  const { accountIndex = 0, addressType = "Base", network = "Mainnet" } = options
+  const { accountIndex = 0, addressType = "Base", networkId = 0 } = options
   const entropy = mnemonicToEntropy(seed, English)
   const rootXPrv = Bip32PrivateKey.fromBip39Entropy(entropy, options?.password ?? "")
   const paymentNode = Bip32PrivateKey.derive(rootXPrv, Bip32PrivateKey.CardanoPath.paymentIndices(accountIndex, 0))
@@ -160,7 +159,6 @@ export function addressFromSeed(
 
   const paymentKeyHash = KeyHash.fromPrivateKey(paymentKey)
   const stakeKeyHash = KeyHash.fromPrivateKey(stakeKey)
-  const networkId = network === "Mainnet" ? 1 : 0
 
   const address =
     addressType === "Base"
@@ -197,10 +195,10 @@ export function walletFromBip32(
   options: {
     addressType?: "Base" | "Enterprise"
     accountIndex?: number
-    network?: "Mainnet" | "Testnet" | "Custom"
+    networkId?: number
   } = {}
 ): SeedDerivationResult {
-  const { accountIndex = 0, addressType = "Base", network = "Mainnet" } = options
+  const { accountIndex = 0, addressType = "Base", networkId = 0 } = options
   const paymentNode = Bip32PrivateKey.derive(rootXPrv, Bip32PrivateKey.CardanoPath.paymentIndices(accountIndex, 0))
   const stakeNode = Bip32PrivateKey.derive(rootXPrv, Bip32PrivateKey.CardanoPath.stakeIndices(accountIndex, 0))
   const paymentKey = Bip32PrivateKey.toPrivateKey(paymentNode)
@@ -208,7 +206,6 @@ export function walletFromBip32(
 
   const paymentKeyHash = KeyHash.fromPrivateKey(paymentKey)
   const stakeKeyHash = KeyHash.fromPrivateKey(stakeKey)
-  const networkId = network === "Mainnet" ? 1 : 0
 
   const address: CoreAddress.Address =
     addressType === "Base"
@@ -265,11 +262,11 @@ export function walletFromPrivateKey(
   options: {
     stakeKeyBech32?: string
     addressType?: "Base" | "Enterprise"
-    network?: "Mainnet" | "Testnet" | "Custom"
+    networkId?: number
   } = {}
 ): Effect.Effect<SeedDerivationResult, DerivationError> {
   return Effect.gen(function* () {
-    const { stakeKeyBech32, addressType = stakeKeyBech32 ? "Base" : "Enterprise", network = "Mainnet" } = options
+    const { stakeKeyBech32, addressType = stakeKeyBech32 ? "Base" : "Enterprise", networkId = 0 } = options
 
     // Use the Effect-based Either API from PrivateKey module - can yield directly on Either
     const paymentKey = yield* Effect.mapError(
@@ -278,8 +275,6 @@ export function walletFromPrivateKey(
       (cause) => new DerivationError({ message: cause.message, cause })
     )
     const paymentKeyHash = KeyHash.fromPrivateKey(paymentKey)
-
-    const networkId = network === "Mainnet" ? 1 : 0
 
     let address: CoreAddress.Address
     let stakeKey: PrivateKey.PrivateKey | undefined

--- a/packages/evolution/test/WalletFromSeed.test.ts
+++ b/packages/evolution/test/WalletFromSeed.test.ts
@@ -13,13 +13,13 @@ describe("WalletFromSeed", () => {
       const result1 = yield* walletFromSeed(seedPhrase, {
         addressType: "Base",
         accountIndex: 0,
-        network: "Mainnet"
+        networkId: 0
       })
 
       expect(Address.toBech32(result1.address)).toBe(
-        "addr1q98wl3hnya9l94rt58ky533deyqe9t8zz5n9su26k8e5g23yar4q0adtaax9q9g0kphpv2ws7vxqwu6ln6pqx7j29nfqsfy9mg"
+        "addr_test1qp8wl3hnya9l94rt58ky533deyqe9t8zz5n9su26k8e5g23yar4q0adtaax9q9g0kphpv2ws7vxqwu6ln6pqx7j29nfqnle9hh"
       )
-      expect(result1.rewardAddress).toBe("stake1uyjw36s87k477nzsz58mqmsk98g0xrq8wd0eaqsr0f9ze5s48wtl9")
+      expect(result1.rewardAddress).toBe("stake_test1uqjw36s87k477nzsz58mqmsk98g0xrq8wd0eaqsr0f9ze5sjdyfmc")
       expect(result1.paymentKey).toBe(
         "ed25519e_sk1krszcw3ujfs3qnsjwl6wynw7dwudgnq69w9lrrtdf46yqnd25dgv4f5ttaqxr2v6n6azee489c7mryudvhu8n4x4tcvd5hvhtwswsuc4s4c2d"
       )
@@ -35,12 +35,33 @@ describe("WalletFromSeed", () => {
     })
   )
 
+  it.effect("Mainnet", () =>
+    Effect.gen(function* () {
+      const result1 = yield* walletFromSeed(seedPhrase, {
+        addressType: "Base",
+        accountIndex: 0,
+        networkId: 1
+      })
+
+      expect(Address.toBech32(result1.address)).toBe(
+        "addr1q98wl3hnya9l94rt58ky533deyqe9t8zz5n9su26k8e5g23yar4q0adtaax9q9g0kphpv2ws7vxqwu6ln6pqx7j29nfqsfy9mg"
+      )
+      expect(result1.rewardAddress).toBe("stake1uyjw36s87k477nzsz58mqmsk98g0xrq8wd0eaqsr0f9ze5s48wtl9")
+      expect(result1.paymentKey).toBe(
+        "ed25519e_sk1krszcw3ujfs3qnsjwl6wynw7dwudgnq69w9lrrtdf46yqnd25dgv4f5ttaqxr2v6n6azee489c7mryudvhu8n4x4tcvd5hvhtwswsuc4s4c2d"
+      )
+      expect(result1.stakeKey).toBe(
+        "ed25519e_sk19q4d6fguvncszk6f46fvvep5y5w3877y77t3n3dc446wgja25dg968hm8jxkc9d7p982uls6k8uq0srs69e44lay43hxmdx4nc3rttsn0h2f5"
+      )
+    })
+  )
+
   it.effect("accountIndex 1", () =>
     Effect.gen(function* () {
       const result1 = yield* walletFromSeed(seedPhrase, {
         addressType: "Base",
         accountIndex: 1,
-        network: "Mainnet"
+        networkId: 1
       })
 
       expect(Address.toBech32(result1.address)).toBe(
@@ -57,39 +78,7 @@ describe("WalletFromSeed", () => {
       const result2 = yield* walletFromSeed(seedPhrase, {
         accountIndex: 1
       })
-      expect(Address.toBech32(result2.address)).toBe(Address.toBech32(result1.address))
-      expect(result2.rewardAddress).toBe(result1.rewardAddress)
-      expect(result2.paymentKey).toBe(result1.paymentKey)
-      expect(result2.stakeKey).toBe(result1.stakeKey)
-    })
-  )
-
-  it.effect("Custom Network", () =>
-    Effect.gen(function* () {
-      const result1 = yield* walletFromSeed(seedPhrase, {
-        addressType: "Base",
-        accountIndex: 0,
-        network: "Custom"
-      })
-
-      expect(Address.toBech32(result1.address)).toBe(
-        "addr_test1qp8wl3hnya9l94rt58ky533deyqe9t8zz5n9su26k8e5g23yar4q0adtaax9q9g0kphpv2ws7vxqwu6ln6pqx7j29nfqnle9hh"
-      )
-      expect(result1.rewardAddress).toBe("stake_test1uqjw36s87k477nzsz58mqmsk98g0xrq8wd0eaqsr0f9ze5sjdyfmc")
-      expect(result1.paymentKey).toBe(
-        "ed25519e_sk1krszcw3ujfs3qnsjwl6wynw7dwudgnq69w9lrrtdf46yqnd25dgv4f5ttaqxr2v6n6azee489c7mryudvhu8n4x4tcvd5hvhtwswsuc4s4c2d"
-      )
-      expect(result1.stakeKey).toBe(
-        "ed25519e_sk19q4d6fguvncszk6f46fvvep5y5w3877y77t3n3dc446wgja25dg968hm8jxkc9d7p982uls6k8uq0srs69e44lay43hxmdx4nc3rttsn0h2f5"
-      )
-
-      const result2 = yield* walletFromSeed(seedPhrase, {
-        network: "Custom"
-      })
-      expect(Address.toBech32(result2.address)).toBe(Address.toBech32(result1.address))
-      expect(result2.rewardAddress).toBe(result1.rewardAddress)
-      expect(result2.paymentKey).toBe(result1.paymentKey)
-      expect(result2.stakeKey).toBe(result1.stakeKey)
+      expect(Address.toBech32(result2.address)).not.toBe(Address.toBech32(result1.address))
     })
   )
 
@@ -98,7 +87,7 @@ describe("WalletFromSeed", () => {
       const result1 = yield* walletFromSeed(seedPhrase, {
         addressType: "Enterprise",
         accountIndex: 0,
-        network: "Mainnet"
+        networkId: 1
       })
 
       expect(Address.toBech32(result1.address)).toBe("addr1v98wl3hnya9l94rt58ky533deyqe9t8zz5n9su26k8e5g2srcn4hd")
@@ -111,7 +100,7 @@ describe("WalletFromSeed", () => {
       const result2 = yield* walletFromSeed(seedPhrase, {
         addressType: "Enterprise"
       })
-      expect(Address.toBech32(result2.address)).toBe(Address.toBech32(result1.address))
+      expect(Address.toBech32(result2.address)).not.toBe(Address.toBech32(result1.address))
       expect(result2.rewardAddress).toBeUndefined()
       expect(result2.paymentKey).toBe(result1.paymentKey)
       expect(result2.stakeKey).toBeUndefined()


### PR DESCRIPTION
The Derivation module required a `network` string option (`"Mainnet" | "Testnet" | "Custom"`) that callers had to construct from a numeric chain ID — and then Derivation immediately converted it back to a number. Devnet docs used `Client.make(preprod)` as a workaround to derive addresses before a cluster existed, which was misleading since `preprod` had nothing to do with devnet.

Add `Address.fromSeed()` that derives an address synchronously from a BIP-39 seed phrase with no `Client` or `Chain` required. Replace the `network` string option with a numeric `networkId` across all Derivation functions, defaulting to `0` (testnet). Update all devnet documentation to use `Address.fromSeed()` for pre-start address derivation and `Cluster.getChain(cluster)` for post-start clients. Add a Yaci DevKit comparison section to the devnet index page.