### PR TITLE
fix(Kupmios): convert credential hash bytes to hex in URL patterns

### DIFF
--- a/.changeset/fix-kupmios-credential-hash.md
+++ b/.changeset/fix-kupmios-credential-hash.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Fixed `getUtxos` and `getUtxosWithUnit` in the Kupmios provider producing invalid Kupo URLs when called with a `Credential` instead of an `Address`. The credential hash (a `Uint8Array`) was being interpolated directly into the URL pattern, resulting in `undefined` or garbage instead of the expected hex string. Both call sites now convert the hash to hex with `Bytes.toHex` before building the URL.

--- a/.changeset/fix-kupmios-credential-hash.md
+++ b/.changeset/fix-kupmios-credential-hash.md
@@ -2,4 +2,4 @@
 "@evolution-sdk/evolution": patch
 ---
 
-Fixed `getUtxos` and `getUtxosWithUnit` in the Kupmios provider producing invalid Kupo URLs when called with a `Credential` instead of an `Address`. The credential hash (a `Uint8Array`) was being interpolated directly into the URL pattern, resulting in `undefined` or garbage instead of the expected hex string. Both call sites now convert the hash to hex with `Bytes.toHex` before building the URL.
+Fixed `getUtxos` and `getUtxosWithUnit` in the Kupmios provider producing invalid Kupo URLs when called with a `Credential` instead of an `Address`. The credential hash (a `Uint8Array`) was being interpolated directly into the URL pattern, resulting in a comma-separated list of byte values instead of the expected hex string. Both call sites now convert the hash to hex with `Bytes.toHex` before building the URL.

--- a/packages/evolution/src/sdk/provider/internal/KupmiosEffects.ts
+++ b/packages/evolution/src/sdk/provider/internal/KupmiosEffects.ts
@@ -216,7 +216,7 @@ export const getUtxosEffect = (kupoUrl: string, headers?: { kupoHeader?: Record<
       const addressStr = CoreAddress.toBech32(addressOrCredential)
       pattern = `${kupoUrl}/matches/${addressStr}?unspent`
     } else {
-      pattern = `${kupoUrl}/matches/${addressOrCredential.hash}/*?unspent`
+      pattern = `${kupoUrl}/matches/${Bytes.toHex(addressOrCredential.hash)}/*?unspent`
     }
     const toUtxos = kupmiosUtxosToUtxos(kupoUrl, headers?.kupoHeader)
 
@@ -348,7 +348,7 @@ export const getUtxosWithUnitEffect = (kupoUrl: string, headers?: { kupoHeader?:
     unit: string
   ) {
     const isAddress = addressOrCredential instanceof CoreAddress.Address
-    const queryPredicate = isAddress ? CoreAddress.toBech32(addressOrCredential) : addressOrCredential.hash
+    const queryPredicate = isAddress ? CoreAddress.toBech32(addressOrCredential) : Bytes.toHex(addressOrCredential.hash)
     const { assetName, policyId } = AssetsUnit.fromUnit(unit)
     const policyIdHex = PolicyId.toHex(policyId)
     const assetNameHex = assetName ? Bytes.toHex(assetName.bytes) : undefined


### PR DESCRIPTION
`getUtxos` and `getUtxosWithUnit` interpolate `Credential.hash` directly into the Kupo URL pattern, but `.hash` is a `Uint8Array` (via `Hash28.BytesFromHex`). JavaScript stringifies it as comma-separated bytes (e.g. `1,2,3,4`) instead of the hex string Kupo expects, producing a 400 Bad Request.

Both call sites now wrap the hash with `Bytes.toHex()` so the URL contains the correct hex-encoded credential hash.

Fixes #248