### PR TITLE
fix: dependabot cooldown semver-patch-days minimum is 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
       default-days: 5
       semver-major-days: 14
       semver-minor-days: 3
-      semver-patch-days: 0
+      semver-patch-days: 1
 
     # Groups — ORDER MATTERS (first match wins)
     # Narrow/risky patterns first, broad/tooling catch-alls last


### PR DESCRIPTION
`semver-patch-days: 0` is invalid — minimum is 1. Fixes the config parse error blocking Dependabot from running.