### PR TITLE
fix: add workaround for Dependabot broken pnpm lockfile

### DIFF
--- a/.github/workflows/dependabot-fix-lockfile.yml
+++ b/.github/workflows/dependabot-fix-lockfile.yml
@@ -1,0 +1,52 @@
+name: Dependabot Fix Lockfile
+
+# Workaround for dependabot-core#13920: Dependabot can generate a malformed
+# pnpm-lock.yaml ("expected a single document in the stream, but found more").
+# This workflow regenerates the lockfile and pushes it back to the PR branch.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  fix-lockfile:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Regenerate lockfile
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet pnpm-lock.yaml 2>/dev/null; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push fixed lockfile
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git commit -m "fix: regenerate pnpm-lock.yaml"
+          git push

--- a/.github/workflows/dependabot-fix-lockfile.yml
+++ b/.github/workflows/dependabot-fix-lockfile.yml
@@ -2,25 +2,29 @@ name: Dependabot Fix Lockfile
 
 # Workaround for dependabot-core#13920: Dependabot can generate a malformed
 # pnpm-lock.yaml ("expected a single document in the stream, but found more").
-# This workflow regenerates the lockfile and pushes it back to the PR branch.
+# This workflow regenerates the lockfile and pushes it back to the branch.
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  push:
+    branches:
+      - 'dependabot/**'
+
+concurrency:
+  group: dependabot-fix-lockfile-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
 
 jobs:
   fix-lockfile:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR branch
+      - name: Checkout Dependabot branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -31,7 +35,7 @@ jobs:
           node-version: 20
 
       - name: Regenerate lockfile
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts
 
       - name: Check for changes
         id: diff
@@ -49,4 +53,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml
           git commit -m "fix: regenerate pnpm-lock.yaml"
-          git push
+          git push origin HEAD:${{ github.ref }}


### PR DESCRIPTION
Dependabot generates a malformed `pnpm-lock.yaml` on pnpm 9 (dependabot-core#13920), causing all CI jobs to fail with `ERR_PNPM_BROKEN_LOCKFILE`.

Adds a workflow that detects Dependabot PRs, regenerates the lockfile with `pnpm install`, and pushes the fix back to the PR branch. CI then runs on the corrected lockfile.