### PR TITLE
fix: remove group-by dependency-name to enable proper grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,6 @@ updates:
           - "effect"
           - "@effect/*"
 
-
       noble-scure-crypto:
         patterns:
           - "@noble/*"
@@ -46,14 +45,12 @@ updates:
           - "bip39"
           - "@types/bip39"
 
-
       cardano-ecosystem:
         patterns:
           - "@dcspark/*"
           - "@emurgo/*"
           - "@cardano-foundation/*"
           - "scalus"
-
 
       # --- Auto-mergeable: tooling groups ---
       eslint:
@@ -63,24 +60,20 @@ updates:
           - "eslint-*"
           - "@typescript-eslint/*"
 
-
       babel:
         patterns:
           - "@babel/*"
           - "babel-plugin-*"
-
 
       vitest:
         patterns:
           - "vitest"
           - "@vitest/*"
 
-
       turbo:
         patterns:
           - "turbo"
           - "@turbo/*"
-
 
       typescript:
         patterns:
@@ -92,11 +85,9 @@ updates:
           - "@types/react"
           - "@types/react-dom"
 
-
       changesets:
         patterns:
           - "@changesets/*"
-
 
       react:
         patterns:
@@ -105,7 +96,6 @@ updates:
           - "@types/react"
           - "@types/react-dom"
           - "@vitejs/plugin-react"
-
 
       docs-tooling:
         patterns:
@@ -124,7 +114,6 @@ updates:
           - "next"
           - "@next/*"
 
-
       # Catch-all for remaining devDependencies — patch + minor only
       # (any dep not matched above that's a devDep)
       misc-devdeps-patch-minor:
@@ -132,7 +121,6 @@ updates:
         update-types:
           - "patch"
           - "minor"
-
 
   # ------------------------------------------------------------
   # GitHub Actions — keep workflow actions up to date

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,7 @@ updates:
         patterns:
           - "effect"
           - "@effect/*"
-        group-by: dependency-name
+
 
       noble-scure-crypto:
         patterns:
@@ -45,7 +45,7 @@ updates:
           - "@scure/*"
           - "bip39"
           - "@types/bip39"
-        group-by: dependency-name
+
 
       cardano-ecosystem:
         patterns:
@@ -53,7 +53,7 @@ updates:
           - "@emurgo/*"
           - "@cardano-foundation/*"
           - "scalus"
-        group-by: dependency-name
+
 
       # --- Auto-mergeable: tooling groups ---
       eslint:
@@ -62,25 +62,25 @@ updates:
           - "@eslint/*"
           - "eslint-*"
           - "@typescript-eslint/*"
-        group-by: dependency-name
+
 
       babel:
         patterns:
           - "@babel/*"
           - "babel-plugin-*"
-        group-by: dependency-name
+
 
       vitest:
         patterns:
           - "vitest"
           - "@vitest/*"
-        group-by: dependency-name
+
 
       turbo:
         patterns:
           - "turbo"
           - "@turbo/*"
-        group-by: dependency-name
+
 
       typescript:
         patterns:
@@ -91,12 +91,12 @@ updates:
           - "@types/dockerode"
           - "@types/react"
           - "@types/react-dom"
-        group-by: dependency-name
+
 
       changesets:
         patterns:
           - "@changesets/*"
-        group-by: dependency-name
+
 
       react:
         patterns:
@@ -105,7 +105,7 @@ updates:
           - "@types/react"
           - "@types/react-dom"
           - "@vitejs/plugin-react"
-        group-by: dependency-name
+
 
       docs-tooling:
         patterns:
@@ -123,7 +123,7 @@ updates:
           - "@orama/*"
           - "next"
           - "@next/*"
-        group-by: dependency-name
+
 
       # Catch-all for remaining devDependencies — patch + minor only
       # (any dep not matched above that's a devDep)
@@ -132,7 +132,7 @@ updates:
         update-types:
           - "patch"
           - "minor"
-        group-by: dependency-name
+
 
   # ------------------------------------------------------------
   # GitHub Actions — keep workflow actions up to date

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -65,7 +65,7 @@ jobs:
 
           # Grouped PRs from allow-listed groups → auto-merge
           case "$DEPENDENCY_GROUP" in
-            eslint|babel|vitest|turbo|typescript|changesets|react|docs-tooling|misc-devdeps-patch-minor|github-actions)
+            eslint|babel|vitest|turbo|typescript|changesets|react|docs-tooling|misc-devdeps-patch-minor)
               echo "mergeable=true" >> "$GITHUB_OUTPUT"
               echo "reason=group '$DEPENDENCY_GROUP' is auto-mergeable" >> "$GITHUB_OUTPUT"
               exit 0


### PR DESCRIPTION
`group-by: dependency-name` is a multi-directory feature that creates one PR per dependency name. With a single `directory: "/"`, it produces individual PRs instead of grouped ones. Removing it enables the default grouping behavior where all matching deps are bundled into one PR per group.