### PR TITLE
fix(provider): credential-based UTxO queries for Blockfrost and Koios

### DIFF
--- a/.changeset/fix-credential-utxo-queries.md
+++ b/.changeset/fix-credential-utxo-queries.md
@@ -1,0 +1,9 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Credential-based UTxO queries (`getUtxos` and `getUtxosWithUnit` with a `Credential` instead of an `Address`) now work across all providers that support them. Previously, passing a `Credential` to Blockfrost produced an invalid API path, and Koios silently rejected the query. Blockfrost now encodes credentials as CIP-5 bech32 (`addr_vkh`/`script` prefixes), and Koios routes credential queries to the `POST /credential_utxos` endpoint with hex-encoded payment credential hashes.
+
+- Added `toBech32`/`fromBech32` to `KeyHash` (`addr_vkh` prefix) and `ScriptHash` (`script` prefix)
+- Added `Credential.toHex` and `Credential.toBech32` convenience functions
+- Fixed `BlockfrostEffect.getUtxosWithUnit` reading the address from `addressPath` instead of the response `utxo.address`

--- a/packages/evolution/src/Credential.ts
+++ b/packages/evolution/src/Credential.ts
@@ -1,5 +1,6 @@
 import { Effect as Eff, FastCheck, ParseResult, Schema } from "effect"
 
+import * as Bytes from "./Bytes.js"
 import * as CBOR from "./CBOR.js"
 import * as KeyHash from "./KeyHash.js"
 import * as ScriptHash from "./ScriptHash.js"
@@ -26,6 +27,30 @@ export type CredentialEncoded = typeof Credential.Encoded
 
 export const makeKeyHash = (hash: Uint8Array): Credential => new KeyHash.KeyHash({ hash })
 export const makeScriptHash = (hash: Uint8Array): Credential => new ScriptHash.ScriptHash({ hash })
+
+/**
+ * Convert a Credential to a hex string of its hash.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toHex = (credential: Credential): string => Bytes.toHex(credential.hash)
+
+/**
+ * Convert a Credential to a bech32 string.
+ * Uses CIP-0005 prefixes: `addr_vkh` for KeyHash, `script` for ScriptHash.
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBech32 = (credential: Credential): string => {
+  switch (credential._tag) {
+    case "KeyHash":
+      return KeyHash.toBech32(credential)
+    case "ScriptHash":
+      return ScriptHash.toBech32(credential)
+  }
+}
 
 /**
  * Check if the given value is a valid Credential

--- a/packages/evolution/src/KeyHash.ts
+++ b/packages/evolution/src/KeyHash.ts
@@ -1,5 +1,6 @@
 import { blake2b } from "@noble/hashes/blake2"
-import { Equal, FastCheck, Hash, Inspectable, Schema } from "effect"
+import { bech32 } from "@scure/base"
+import { Effect as Eff, Equal, FastCheck, Hash, Inspectable, ParseResult, Schema } from "effect"
 
 import * as Bytes from "./Bytes.js"
 import * as Hash28 from "./Hash28.js"
@@ -99,6 +100,52 @@ export const toBytes = Schema.encodeSync(FromBytes)
  * @category encoding/decoding
  */
 export const toHex = Schema.encodeSync(FromHex)
+
+/**
+ * Schema transformer from bech32 string (addr_vkh1...) to KeyHash.
+ * Uses the CIP-0005 `addr_vkh` prefix for address verification key hashes.
+ *
+ * @since 2.0.0
+ * @category transformer
+ */
+export const FromBech32 = Schema.transformOrFail(Schema.String, Schema.typeSchema(KeyHash), {
+  strict: true,
+  encode: (keyHash) =>
+    Eff.gen(function* () {
+      const words = bech32.toWords(keyHash.hash)
+      return bech32.encode("addr_vkh", words, false)
+    }),
+  decode: (fromA, _, ast) =>
+    Eff.gen(function* () {
+      const result = yield* Eff.try({
+        try: () => {
+          const decoded = bech32.decode(fromA as any, false)
+          return new Uint8Array(bech32.fromWords(decoded.words))
+        },
+        catch: () => new ParseResult.Type(ast, fromA, `Failed to decode Bech32 key hash: ${fromA}`)
+      })
+      return yield* ParseResult.decode(FromBytes)(result)
+    })
+}).annotations({
+  identifier: "KeyHash.FromBech32",
+  description: "Transforms Bech32 addr_vkh string to KeyHash"
+})
+
+/**
+ * Parse a KeyHash from a bech32 string (addr_vkh1...).
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromBech32 = Schema.decodeSync(FromBech32)
+
+/**
+ * Convert a KeyHash to a bech32 string (addr_vkh1...).
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const toBech32 = Schema.encodeSync(FromBech32)
 
 /**
  * FastCheck arbitrary for generating random KeyHash instances.

--- a/packages/evolution/src/ScriptHash.ts
+++ b/packages/evolution/src/ScriptHash.ts
@@ -1,5 +1,6 @@
 import { blake2b } from "@noble/hashes/blake2"
-import { Equal, FastCheck, Hash, Inspectable, Schema } from "effect"
+import { bech32 } from "@scure/base"
+import { Effect as Eff, Equal, FastCheck, Hash, Inspectable, ParseResult, Schema } from "effect"
 
 import * as Bytes from "./Bytes.js"
 import * as Hash28 from "./Hash28.js"
@@ -102,6 +103,52 @@ export const toBytes = Schema.encodeSync(FromBytes)
  * @category encoding
  */
 export const toHex = Schema.encodeSync(FromHex)
+
+/**
+ * Schema transformer from bech32 string (script1...) to ScriptHash.
+ * Uses the CIP-0005 `script` prefix for script hashes.
+ *
+ * @since 2.0.0
+ * @category schemas
+ */
+export const FromBech32 = Schema.transformOrFail(Schema.String, Schema.typeSchema(ScriptHash), {
+  strict: true,
+  encode: (scriptHash) =>
+    Eff.gen(function* () {
+      const words = bech32.toWords(scriptHash.hash)
+      return bech32.encode("script", words, false)
+    }),
+  decode: (fromA, _, ast) =>
+    Eff.gen(function* () {
+      const result = yield* Eff.try({
+        try: () => {
+          const decoded = bech32.decode(fromA as any, false)
+          return new Uint8Array(bech32.fromWords(decoded.words))
+        },
+        catch: () => new ParseResult.Type(ast, fromA, `Failed to decode Bech32 script hash: ${fromA}`)
+      })
+      return yield* ParseResult.decode(FromBytes)(result)
+    })
+}).annotations({
+  identifier: "ScriptHash.FromBech32",
+  description: "Transforms Bech32 script string to ScriptHash"
+})
+
+/**
+ * Parse a ScriptHash from a bech32 string (script1...).
+ *
+ * @since 2.0.0
+ * @category parsing
+ */
+export const fromBech32 = Schema.decodeSync(FromBech32)
+
+/**
+ * Convert a ScriptHash to a bech32 string (script1...).
+ *
+ * @since 2.0.0
+ * @category encoding
+ */
+export const toBech32 = Schema.encodeSync(FromBech32)
 
 /**
  * FastCheck arbitrary for generating random ScriptHash instances.

--- a/packages/evolution/src/sdk/provider/internal/BlockfrostEffect.ts
+++ b/packages/evolution/src/sdk/provider/internal/BlockfrostEffect.ts
@@ -9,7 +9,7 @@ import { Effect, Schedule, Schema } from "effect"
 import * as CoreAddress from "../../../Address.js"
 import * as AssetName from "../../../AssetName.js"
 import * as Bytes from "../../../Bytes.js"
-import type * as Credential from "../../../Credential.js"
+import * as Credential from "../../../Credential.js"
 import * as PlutusData from "../../../Data.js"
 import * as DatumHash from "../../../DatumHash.js"
 import type * as DatumOption from "../../../DatumOption.js"
@@ -73,15 +73,15 @@ const is404Error = (error: unknown): boolean => {
 }
 
 /**
- * Convert address or credential to appropriate Blockfrost endpoint path
+ * Convert address or credential to Blockfrost endpoint path.
+ * Blockfrost /addresses/{address} endpoints accept payment credentials
+ * in bech32 format (CIP-0005: addr_vkh for key hashes, script for script hashes).
  */
 const getAddressPath = (addressOrCredential: CoreAddress.Address | Credential.Credential): string => {
-  // For Core Address, convert to bech32 string
   if (addressOrCredential instanceof CoreAddress.Address) {
     return CoreAddress.toBech32(addressOrCredential)
   }
-  // For Credential, convert to string representation
-  return addressOrCredential.toString()
+  return Credential.toBech32(addressOrCredential)
 }
 
 const toBlockfrostValue = (
@@ -429,7 +429,7 @@ export const getUtxosWithUnit =
       return Effect.all([scriptEffect, datumEffect]).pipe(
         Effect.map(([scriptRef, datumOption]) => {
           const assets = Blockfrost.transformAmounts(utxo.amount)
-          const address = CoreAddress.fromBech32(addressPath)
+          const address = CoreAddress.fromBech32(utxo.address)
           const transactionId = TransactionHash.fromHex(utxo.tx_hash)
 
           return new CoreUTxO.UTxO({

--- a/packages/evolution/src/sdk/provider/internal/Koios.ts
+++ b/packages/evolution/src/sdk/provider/internal/Koios.ts
@@ -6,7 +6,6 @@ import type { ParseError } from "effect/ParseResult"
 import * as CoreAddress from "../../../Address.js"
 import * as CoreAssets from "../../../Assets.js"
 import * as Bytes from "../../../Bytes.js"
-import type * as Credential from "../../../Credential.js"
 import * as PlutusData from "../../../Data.js"
 import * as DatumHash from "../../../DatumHash.js"
 import type * as DatumOption from "../../../DatumOption.js"
@@ -340,9 +339,25 @@ export const toUTxO = (koiosUTxO: UTxO, addressStr: string): CoreUTxO.UTxO => {
   })
 }
 
+export const CredentialUTxOSchema = Schema.Struct({
+  tx_hash: Schema.String,
+  tx_index: Schema.Number,
+  address: Schema.String,
+  value: Schema.String,
+  datum_hash: Schema.NullOr(Schema.String),
+  inline_datum: Schema.NullOr(
+    Schema.Struct({
+      bytes: Schema.NullOr(Schema.String),
+      value: Schema.Unknown
+    })
+  ),
+  reference_script: Schema.NullOr(ReferenceScriptSchema),
+  asset_list: Schema.NullOr(Schema.Array(AssetSchema))
+})
+
 export const getUtxosEffect = (
   baseUrl: string,
-  addressOrCredential: string | Credential.Credential,
+  address: string,
   headers: Record<string, string> | undefined
 ): Effect.Effect<
   Array<CoreUTxO.UTxO>,
@@ -351,15 +366,48 @@ export const getUtxosEffect = (
 > => {
   const url = `${baseUrl}/address_info`
   const body = {
-    _addresses: [addressOrCredential]
+    _addresses: [address]
   }
-  const schema = AddressInfoSchema
   const result = pipe(
-    Effect.if(typeof addressOrCredential === "string", {
-      onFalse: () => Effect.fail("Credential Type is not supported in Koios yet."),
-      onTrue: () => HttpUtils.postJson(url, body, schema, headers)
-    }),
+    HttpUtils.postJson(url, body, AddressInfoSchema, headers),
     Effect.map(([result]) => (result ? result.utxo_set.map((koiosUtxo) => toUTxO(koiosUtxo, result.address)) : [])),
+    Effect.provide(FetchHttpClient.layer)
+  )
+  return result
+}
+
+export const getCredentialUtxosEffect = (
+  baseUrl: string,
+  credentialHash: string,
+  headers: Record<string, string> | undefined
+): Effect.Effect<
+  Array<CoreUTxO.UTxO>,
+  string | HttpBody.HttpBodyError | HttpClientError.HttpClientError | ParseError,
+  never
+> => {
+  const url = `${baseUrl}/credential_utxos`
+  const body = {
+    _payment_credentials: [credentialHash],
+    _extended: true
+  }
+  const result = pipe(
+    HttpUtils.postJson(url, body, Schema.Array(CredentialUTxOSchema), headers),
+    Effect.map((utxos) =>
+      utxos.map((u) => toUTxO(
+        {
+          tx_hash: u.tx_hash,
+          tx_index: u.tx_index,
+          block_time: 0,
+          block_height: null,
+          value: u.value,
+          datum_hash: u.datum_hash,
+          inline_datum: u.inline_datum,
+          reference_script: u.reference_script,
+          asset_list: u.asset_list
+        },
+        u.address
+      ))
+    ),
     Effect.provide(FetchHttpClient.layer)
   )
   return result

--- a/packages/evolution/src/sdk/provider/internal/KoiosEffect.ts
+++ b/packages/evolution/src/sdk/provider/internal/KoiosEffect.ts
@@ -4,7 +4,7 @@ import { Effect, pipe, Schedule, Schema } from "effect"
 import * as CoreAddress from "../../../Address.js"
 import * as CoreAssets from "../../../Assets.js"
 import * as Bytes from "../../../Bytes.js"
-import type * as Credential from "../../../Credential.js"
+import * as Credential from "../../../Credential.js"
 import * as PlutusData from "../../../Data.js"
 import type * as DatumHash from "../../../DatumHash.js"
 import * as PolicyId from "../../../PolicyId.js"
@@ -71,30 +71,31 @@ export const getProtocolParameters = (baseUrl: string, token?: string) =>
     }
   })
 
+const getUtxosForAddressOrCredential = (
+  baseUrl: string,
+  addressOrCredential: CoreAddress.Address | Credential.Credential,
+  token?: string
+) => {
+  const headers = token ? { Authorization: `Bearer ${token}` } : undefined
+  if (addressOrCredential instanceof CoreAddress.Address) {
+    return _Koios.getUtxosEffect(baseUrl, CoreAddress.toBech32(addressOrCredential), headers)
+  }
+  return _Koios.getCredentialUtxosEffect(baseUrl, Credential.toHex(addressOrCredential), headers)
+}
+
 export const getUtxos =
-  (baseUrl: string, token?: string) => (addressOrCredential: CoreAddress.Address | Credential.Credential) => {
-    // Convert CoreAddress to Bech32 string for Koios API
-    const addressStr =
-      addressOrCredential instanceof CoreAddress.Address
-        ? CoreAddress.toBech32(addressOrCredential)
-        : addressOrCredential
-    return pipe(
-      _Koios.getUtxosEffect(baseUrl, addressStr, token ? { Authorization: `Bearer ${token}` } : undefined),
+  (baseUrl: string, token?: string) => (addressOrCredential: CoreAddress.Address | Credential.Credential) =>
+    pipe(
+      getUtxosForAddressOrCredential(baseUrl, addressOrCredential, token),
       Effect.timeout(10_000),
       Effect.catchAll(wrapError("getUtxos"))
     )
-  }
 
 export const getUtxosWithUnit =
   (baseUrl: string, token?: string) =>
-  (addressOrCredential: CoreAddress.Address | Credential.Credential, unit: string) => {
-    // Convert CoreAddress to Bech32 string for Koios API
-    const addressStr =
-      addressOrCredential instanceof CoreAddress.Address
-        ? CoreAddress.toBech32(addressOrCredential)
-        : addressOrCredential
-    return pipe(
-      _Koios.getUtxosEffect(baseUrl, addressStr, token ? { Authorization: `Bearer ${token}` } : undefined),
+  (addressOrCredential: CoreAddress.Address | Credential.Credential, unit: string) =>
+    pipe(
+      getUtxosForAddressOrCredential(baseUrl, addressOrCredential, token),
       Effect.map((utxos) =>
         utxos.filter((utxo) => {
           const units = CoreAssets.getUnits(utxo.assets)
@@ -104,7 +105,6 @@ export const getUtxosWithUnit =
       Effect.timeout(10_000),
       Effect.catchAll(wrapError("getUtxosWithUnit"))
     )
-  }
 
 export const getUtxoByUnit = (baseUrl: string, token?: string) => (unit: string) =>
   pipe(

--- a/packages/evolution/test/provider/conformance.ts
+++ b/packages/evolution/test/provider/conformance.ts
@@ -2,6 +2,7 @@ import { beforeAll, expect, it } from "vitest"
 
 import * as Address from "../../src/Address.js"
 import * as Assets from "../../src/Assets.js"
+import * as Credential from "../../src/Credential.js"
 import * as PoolKeyHash from "../../src/PoolKeyHash.js"
 import { type Provider } from "../../src/sdk/provider/Provider.js"
 import * as Transaction from "../../src/Transaction.js"
@@ -30,7 +31,12 @@ import { evalSample1, evalSample2, evalSample3, evalSample4 } from "./fixtures/e
  * Schema validation inside the provider guarantees type correctness —
  * assertions here focus on sanity (non-empty, positive, expected shape).
  */
-export function registerConformanceTests(factory: () => Provider) {
+export interface ConformanceOptions {
+  supportsCredentialQueries?: boolean
+}
+
+export function registerConformanceTests(factory: () => Provider, options?: ConformanceOptions) {
+  const { supportsCredentialQueries = false } = options ?? {}
   let provider: Provider
   beforeAll(() => {
     provider = factory()
@@ -51,6 +57,22 @@ export function registerConformanceTests(factory: () => Provider) {
 
   it("getUtxosWithUnit", async () => {
     const utxos = await provider.getUtxosWithUnit(preprodScriptAddress(), PREPROD_UNIT)
+    expect(utxos).toBeInstanceOf(Array)
+    expect(utxos.length).toBeGreaterThan(0)
+  })
+
+  it.skipIf(!supportsCredentialQueries)("getUtxos with Credential", async () => {
+    const credential = preprodAddress().paymentCredential
+    expect(Credential.is(credential)).toBe(true)
+    const utxos = await provider.getUtxos(credential)
+    expect(utxos).toBeInstanceOf(Array)
+    expect(utxos.length).toBeGreaterThan(0)
+  })
+
+  it.skipIf(!supportsCredentialQueries)("getUtxosWithUnit with Credential", async () => {
+    const credential = preprodScriptAddress().paymentCredential
+    expect(Credential.is(credential)).toBe(true)
+    const utxos = await provider.getUtxosWithUnit(credential, PREPROD_UNIT)
     expect(utxos).toBeInstanceOf(Array)
     expect(utxos.length).toBeGreaterThan(0)
   })

--- a/packages/evolution/test/provider/providers.test.ts
+++ b/packages/evolution/test/provider/providers.test.ts
@@ -46,7 +46,7 @@ const OGMIOS_HEADER = parseHeaderJson(process.env.KUPMIOS_OGMIOS_HEADER_JSON) ??
 
 // ── Koios (no API key) ────────────────────────────────────────────────────────
 describe.skipIf(!process.env.KOIOS_ENABLED)("Koios", () => {
-  registerConformanceTests(() => new Koios(KOIOS_URL))
+  registerConformanceTests(() => new Koios(KOIOS_URL), { supportsCredentialQueries: true })
 })
 
 // ── Koios preview: awaitTx with Haskell show string asset_list ────────────────
@@ -63,7 +63,7 @@ describe.skipIf(!process.env.KOIOS_PREVIEW_ENABLED)("Koios (preview)", () => {
 
 // ── Blockfrost ────────────────────────────────────────────────────────────────
 describe.skipIf(!isConfigured(BLOCKFROST_KEY, "preprodXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"))("Blockfrost", () => {
-  registerConformanceTests(() => new BlockfrostProvider(BLOCKFROST_URL, BLOCKFROST_KEY))
+  registerConformanceTests(() => new BlockfrostProvider(BLOCKFROST_URL, BLOCKFROST_KEY), { supportsCredentialQueries: true })
 })
 
 // ── Maestro ───────────────────────────────────────────────────────────────────
@@ -81,6 +81,7 @@ describe.skipIf(
       new KupmiosProvider(KUPO_URL!, OGMIOS_URL!, {
         kupoHeader: KUPO_HEADER,
         ogmiosHeader: OGMIOS_HEADER
-      })
+      }),
+    { supportsCredentialQueries: true }
   )
 })


### PR DESCRIPTION
Passing a `Credential` instead of an `Address` to `getUtxos`/`getUtxosWithUnit` produced invalid API requests on Blockfrost (garbage path from `toString()`) and Koios (raw object passed where a string was expected). Kupmios already handled credentials correctly.

Blockfrost now encodes credentials as CIP-5 bech32 via `Credential.toBech32`, and Koios routes credential queries to `POST /credential_utxos` with hex payment credential hashes. Added `toBech32`/`fromBech32` to `KeyHash` and `ScriptHash`, and `toHex`/`toBech32` to `Credential`. Fixed `BlockfrostEffect.getUtxosWithUnit` reading the address from `addressPath` instead of `utxo.address`.

Closes #304