### PR TITLE
refactor(pay): make autoMinUtxo opt-in via BuildOptions

### DIFF
--- a/.changeset/auto-min-utxo.md
+++ b/.changeset/auto-min-utxo.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": minor
+---
+
+Add opt-in `autoMinUtxo` to `TxBuilderConfig` and `PayToAddressParams` for automatic minimum UTxO lovelace enforcement

--- a/.changeset/auto-min-utxo.md
+++ b/.changeset/auto-min-utxo.md
@@ -1,5 +1,5 @@
 ---
-"@evolution-sdk/evolution": minor
+"@evolution-sdk/evolution": patch
 ---
 
 Add opt-in `autoMinUtxo` to `TxBuilderConfig` and `PayToAddressParams` for automatic minimum UTxO lovelace enforcement

--- a/.changeset/auto-min-utxo.md
+++ b/.changeset/auto-min-utxo.md
@@ -2,4 +2,4 @@
 "@evolution-sdk/evolution": patch
 ---
 
-Add opt-in `autoMinUtxo` to `TxBuilderConfig` and `PayToAddressParams` for automatic minimum UTxO lovelace enforcement
+Add opt-in `autoMinUtxo` to `BuildOptions` and `PayToAddressParams` for automatic minimum UTxO lovelace enforcement

--- a/packages/evolution/src/sdk/builders/TransactionBuilder.ts
+++ b/packages/evolution/src/sdk/builders/TransactionBuilder.ts
@@ -591,8 +591,7 @@ export interface BuildOptions {
   /**
    * When `true`, `payToAddress` outputs whose lovelace is below the protocol
    * minimum are automatically bumped up to the required minimum.
-   * When `false` or omitted (the default), under-funded outputs are passed
-   * through as-is and the node will reject them.
+   * When `false` or omitted (the default), under-funded outputs are used as-is.
    *
    * Can be overridden per-call via `PayToAddressParams.autoMinUtxo`.
    *

--- a/packages/evolution/src/sdk/builders/TransactionBuilder.ts
+++ b/packages/evolution/src/sdk/builders/TransactionBuilder.ts
@@ -418,6 +418,18 @@ export interface TxBuilderConfig {
    * @since 2.0.0
    */
   readonly chain: Chain
+
+  /**
+   * When `true`, `payToAddress` outputs whose lovelace is below the protocol
+   * minimum are automatically bumped up to the required minimum.
+   * When `false` or omitted (the default), under-funded outputs are passed
+   * through as-is and the node will reject them.
+   *
+   * Can be overridden per-call via `PayToAddressParams.autoMinUtxo`.
+   *
+   * @since 2.0.0
+   */
+  readonly autoMinUtxo?: boolean
 }
 
 /**
@@ -1720,7 +1732,9 @@ export type TransactionBuilder = SigningTransactionBuilder | ReadOnlyTransaction
 export function makeTxBuilder(
   config: TxBuilderConfig & { wallet: Wallet.SigningWallet | Wallet.ApiWallet }
 ): SigningTransactionBuilder
-export function makeTxBuilder(config: TxBuilderConfig & { wallet: Wallet.ReadOnlyWallet }): ReadOnlyTransactionBuilder
+export function makeTxBuilder(
+  config: TxBuilderConfig & { wallet: Wallet.ReadOnlyWallet }
+): ReadOnlyTransactionBuilder
 export function makeTxBuilder(config: TxBuilderConfig & { wallet?: undefined }): ReadOnlyTransactionBuilder
 export function makeTxBuilder(config: TxBuilderConfig): SigningTransactionBuilder | ReadOnlyTransactionBuilder {
   return BuilderFactory.makeTxBuilder(config)

--- a/packages/evolution/src/sdk/builders/TransactionBuilder.ts
+++ b/packages/evolution/src/sdk/builders/TransactionBuilder.ts
@@ -419,17 +419,6 @@ export interface TxBuilderConfig {
    */
   readonly chain: Chain
 
-  /**
-   * When `true`, `payToAddress` outputs whose lovelace is below the protocol
-   * minimum are automatically bumped up to the required minimum.
-   * When `false` or omitted (the default), under-funded outputs are passed
-   * through as-is and the node will reject them.
-   *
-   * Can be overridden per-call via `PayToAddressParams.autoMinUtxo`.
-   *
-   * @since 2.0.0
-   */
-  readonly autoMinUtxo?: boolean
 }
 
 /**
@@ -598,6 +587,18 @@ export interface BuildOptions {
    * @since 2.0.0
    */
   readonly debug?: boolean
+
+  /**
+   * When `true`, `payToAddress` outputs whose lovelace is below the protocol
+   * minimum are automatically bumped up to the required minimum.
+   * When `false` or omitted (the default), under-funded outputs are passed
+   * through as-is and the node will reject them.
+   *
+   * Can be overridden per-call via `PayToAddressParams.autoMinUtxo`.
+   *
+   * @since 2.0.0
+   */
+  readonly autoMinUtxo?: boolean
 }
 
 // ============================================================================

--- a/packages/evolution/src/sdk/builders/operations/Operations.ts
+++ b/packages/evolution/src/sdk/builders/operations/Operations.ts
@@ -47,6 +47,8 @@ export interface PayToAddressParams {
   readonly datum?: CoreDatumOption.DatumOption
   /** Optional script to store as a reference script in the output */
   readonly script?: CoreScript.Script
+  /** Override the builder-level `autoMinUtxo` setting for this specific output. */
+  readonly autoMinUtxo?: boolean
 }
 
 /**

--- a/packages/evolution/src/sdk/builders/operations/Operations.ts
+++ b/packages/evolution/src/sdk/builders/operations/Operations.ts
@@ -47,7 +47,7 @@ export interface PayToAddressParams {
   readonly datum?: CoreDatumOption.DatumOption
   /** Optional script to store as a reference script in the output */
   readonly script?: CoreScript.Script
-  /** Override the builder-level `autoMinUtxo` setting for this specific output. */
+  /** Override the build-level `autoMinUtxo` setting for this specific output. */
   readonly autoMinUtxo?: boolean
 }
 

--- a/packages/evolution/src/sdk/builders/operations/Pay.ts
+++ b/packages/evolution/src/sdk/builders/operations/Pay.ts
@@ -17,13 +17,13 @@ import type { PayToAddressParams } from "./Operations.js"
  * Creates a ProgramStep for payToAddress operation.
  * Creates a UTxO output and tracks assets for balancing.
  *
- * When `autoMinUtxo` is enabled (via builder config or per-call override),
+ * When `autoMinUtxo` is enabled (via build options or per-call override),
  * the output lovelace is automatically bumped up to the protocol minimum
  * if the specified amount is below it. When disabled (the default), the
  * specified lovelace is used as-is.
  *
  * Implementation:
- * 1. Resolves autoMinUtxo from per-call override or builder config (default: off)
+ * 1. Resolves autoMinUtxo from per-call override or build options (default: off)
  * 2. When enabled, calculates minimum lovelace and uses the higher of specified/required
  * 3. Creates the UTxO output with the effective assets
  * 4. Adds output to state.outputs array

--- a/packages/evolution/src/sdk/builders/operations/Pay.ts
+++ b/packages/evolution/src/sdk/builders/operations/Pay.ts
@@ -10,7 +10,7 @@ import { Effect, Ref } from "effect"
 import * as CoreAssets from "../../../Assets.js"
 import { calculateMinimumUtxoLovelace, makeTxOutput } from "../internal/txBuilder.js"
 import type { TransactionBuilderError } from "../TransactionBuilder.js"
-import { ProtocolParametersTag, TxBuilderConfigTag, TxContext } from "../TransactionBuilder.js"
+import { BuildOptionsTag, ProtocolParametersTag, TxContext } from "../TransactionBuilder.js"
 import type { PayToAddressParams } from "./Operations.js"
 
 /**
@@ -35,8 +35,8 @@ import type { PayToAddressParams } from "./Operations.js"
 export const createPayToAddressProgram = (params: PayToAddressParams) =>
   Effect.gen(function* () {
     const ctx = yield* TxContext
-    const config = yield* TxBuilderConfigTag
-    const shouldBump = params.autoMinUtxo ?? config.autoMinUtxo ?? false
+    const buildOptions = yield* BuildOptionsTag
+    const shouldBump = params.autoMinUtxo ?? buildOptions.autoMinUtxo ?? false
 
     let effectiveAssets = params.assets
 
@@ -72,5 +72,5 @@ export const createPayToAddressProgram = (params: PayToAddressParams) =>
   }) satisfies Effect.Effect<
     void,
     TransactionBuilderError,
-    ProtocolParametersTag | TxContext | TxBuilderConfigTag
+    ProtocolParametersTag | TxContext | BuildOptionsTag
   >

--- a/packages/evolution/src/sdk/builders/operations/Pay.ts
+++ b/packages/evolution/src/sdk/builders/operations/Pay.ts
@@ -9,25 +9,25 @@ import { Effect, Ref } from "effect"
 
 import * as CoreAssets from "../../../Assets.js"
 import { calculateMinimumUtxoLovelace, makeTxOutput } from "../internal/txBuilder.js"
-import { ProtocolParametersTag, TransactionBuilderError, TxContext } from "../TransactionBuilder.js"
+import type { TransactionBuilderError } from "../TransactionBuilder.js"
+import { ProtocolParametersTag, TxBuilderConfigTag, TxContext } from "../TransactionBuilder.js"
 import type { PayToAddressParams } from "./Operations.js"
 
 /**
  * Creates a ProgramStep for payToAddress operation.
  * Creates a UTxO output and tracks assets for balancing.
  *
- * Automatically enforces the minimum UTxO lovelace requirement: if the caller
- * provides lovelace below the protocol-parameter minimum (or omits it entirely),
- * the output is silently bumped up to the required minimum.  This mirrors the
- * behaviour of the change-creation phase and prevents on-chain rejections due
- * to dust outputs.
+ * When `autoMinUtxo` is enabled (via builder config or per-call override),
+ * the output lovelace is automatically bumped up to the protocol minimum
+ * if the specified amount is below it. When disabled (the default), the
+ * specified lovelace is used as-is.
  *
  * Implementation:
- * 1. Calculates the minimum lovelace for the requested output
- * 2. Uses the higher of the specified and required lovelace
+ * 1. Resolves autoMinUtxo from per-call override or builder config (default: off)
+ * 2. When enabled, calculates minimum lovelace and uses the higher of specified/required
  * 3. Creates the UTxO output with the effective assets
  * 4. Adds output to state.outputs array
- * 5. Updates totalOutputAssets for balancing (using the effective amount)
+ * 5. Updates totalOutputAssets for balancing
  *
  * @since 2.0.0
  * @category programs
@@ -35,26 +35,28 @@ import type { PayToAddressParams } from "./Operations.js"
 export const createPayToAddressProgram = (params: PayToAddressParams) =>
   Effect.gen(function* () {
     const ctx = yield* TxContext
-    const protocolParams = yield* ProtocolParametersTag
+    const config = yield* TxBuilderConfigTag
+    const shouldBump = params.autoMinUtxo ?? config.autoMinUtxo ?? false
 
-    // 1. Calculate the minimum lovelace required for this output
-    const minLovelace = yield* calculateMinimumUtxoLovelace({
-      address: params.address,
-      assets: params.assets,
-      datum: params.datum,
-      scriptRef: params.script,
-      coinsPerUtxoByte: protocolParams.coinsPerUtxoByte
-    })
+    let effectiveAssets = params.assets
 
-    // 2. Enforce minimum: silently bump lovelace up if below minimum
-    const specifiedLovelace = CoreAssets.lovelaceOf(params.assets)
-    const effectiveLovelace = specifiedLovelace < minLovelace ? minLovelace : specifiedLovelace
-    const effectiveAssets =
-      effectiveLovelace !== specifiedLovelace
-        ? CoreAssets.withLovelace(params.assets, effectiveLovelace)
-        : params.assets
+    if (shouldBump) {
+      const protocolParams = yield* ProtocolParametersTag
 
-    // 3. Create Core TransactionOutput from effective params
+      const minLovelace = yield* calculateMinimumUtxoLovelace({
+        address: params.address,
+        assets: params.assets,
+        datum: params.datum,
+        scriptRef: params.script,
+        coinsPerUtxoByte: protocolParams.coinsPerUtxoByte
+      })
+
+      const specifiedLovelace = CoreAssets.lovelaceOf(params.assets)
+      if (specifiedLovelace < minLovelace) {
+        effectiveAssets = CoreAssets.withLovelace(params.assets, minLovelace)
+      }
+    }
+
     const output = makeTxOutput({
       address: params.address,
       assets: effectiveAssets,
@@ -62,10 +64,13 @@ export const createPayToAddressProgram = (params: PayToAddressParams) =>
       scriptRef: params.script
     })
 
-    // 4. Add output to state (totalOutputAssets uses effective lovelace for accurate balancing)
     yield* Ref.update(ctx, (state) => ({
       ...state,
       outputs: [...state.outputs, output],
       totalOutputAssets: CoreAssets.merge(state.totalOutputAssets, effectiveAssets)
     }))
-  }) satisfies Effect.Effect<void, TransactionBuilderError, ProtocolParametersTag | TxContext>
+  }) satisfies Effect.Effect<
+    void,
+    TransactionBuilderError,
+    ProtocolParametersTag | TxContext | TxBuilderConfigTag
+  >

--- a/packages/evolution/test/TxBuilder.PayMinUtxo.test.ts
+++ b/packages/evolution/test/TxBuilder.PayMinUtxo.test.ts
@@ -31,13 +31,21 @@ const expectedMinLovelace = (assets: CoreAssets.Assets) =>
 
 const buildAndGetFirstOutput = async (
   receiverAssets: CoreAssets.Assets,
-  walletLovelace = 10_000_000n,
-  walletNativeAssets?: Record<string, bigint>
+  options?: {
+    walletLovelace?: bigint
+    walletNativeAssets?: Record<string, bigint>
+    autoMinUtxo?: boolean
+    perCallAutoMinUtxo?: boolean
+  }
 ) => {
-  const signBuilder = await makeTxBuilder({ chain: mainnet })
+  const walletLovelace = options?.walletLovelace ?? 10_000_000n
+  const builderAutoMinUtxo = options?.autoMinUtxo ?? true
+
+  const signBuilder = await makeTxBuilder({ chain: mainnet, autoMinUtxo: builderAutoMinUtxo })
     .payToAddress({
       address: Address.fromBech32(RECEIVER_ADDRESS),
-      assets: receiverAssets
+      assets: receiverAssets,
+      ...(options?.perCallAutoMinUtxo !== undefined && { autoMinUtxo: options.perCallAutoMinUtxo })
     })
     .build({
       changeAddress: Address.fromBech32(CHANGE_ADDRESS),
@@ -47,7 +55,7 @@ const buildAndGetFirstOutput = async (
           index: 0n,
           address: CHANGE_ADDRESS,
           lovelace: walletLovelace,
-          nativeAssets: walletNativeAssets
+          nativeAssets: options?.walletNativeAssets
         })
       ],
       protocolParameters: PROTOCOL_PARAMS
@@ -104,11 +112,41 @@ describe("TxBuilder – payToAddress auto min-ADA enforcement", () => {
     const minLovelace = await expectedMinLovelace(requestedAssets)
     const adaOnlyMin = await expectedMinLovelace(CoreAssets.fromLovelace(0n))
 
-    const output = await buildAndGetFirstOutput(requestedAssets, 10_000_000n, {
-      [TOKEN_UNIT]: 1_000n
+    const output = await buildAndGetFirstOutput(requestedAssets, {
+      walletNativeAssets: { [TOKEN_UNIT]: 1_000n }
     })
 
     expect(output.assets.lovelace).toBe(minLovelace)
     expect(minLovelace).toBeGreaterThan(adaOnlyMin)
+  })
+
+  it("does not bump when autoMinUtxo is off (default)", async () => {
+    const output = await buildAndGetFirstOutput(CoreAssets.fromLovelace(2_000_000n), {
+      autoMinUtxo: false
+    })
+
+    expect(output.assets.lovelace).toBe(2_000_000n)
+  })
+
+  it("per-call autoMinUtxo: false overrides builder-level true", async () => {
+    const output = await buildAndGetFirstOutput(CoreAssets.fromLovelace(2_000_000n), {
+      autoMinUtxo: true,
+      perCallAutoMinUtxo: false
+    })
+
+    expect(output.assets.lovelace).toBe(2_000_000n)
+  })
+
+  it("per-call autoMinUtxo: true bumps even when builder default is off", async () => {
+    const requested = CoreAssets.fromLovelace(0n)
+    const minLovelace = await expectedMinLovelace(requested)
+
+    const output = await buildAndGetFirstOutput(requested, {
+      autoMinUtxo: false,
+      perCallAutoMinUtxo: true
+    })
+
+    expect(output.assets.lovelace).toBe(minLovelace)
+    expect(minLovelace).toBeGreaterThan(0n)
   })
 })

--- a/packages/evolution/test/TxBuilder.PayMinUtxo.test.ts
+++ b/packages/evolution/test/TxBuilder.PayMinUtxo.test.ts
@@ -39,9 +39,9 @@ const buildAndGetFirstOutput = async (
   }
 ) => {
   const walletLovelace = options?.walletLovelace ?? 10_000_000n
-  const builderAutoMinUtxo = options?.autoMinUtxo ?? true
+  const buildAutoMinUtxo = options?.autoMinUtxo ?? true
 
-  const signBuilder = await makeTxBuilder({ chain: mainnet, autoMinUtxo: builderAutoMinUtxo })
+  const signBuilder = await makeTxBuilder({ chain: mainnet })
     .payToAddress({
       address: Address.fromBech32(RECEIVER_ADDRESS),
       assets: receiverAssets,
@@ -58,7 +58,8 @@ const buildAndGetFirstOutput = async (
           nativeAssets: options?.walletNativeAssets
         })
       ],
-      protocolParameters: PROTOCOL_PARAMS
+      protocolParameters: PROTOCOL_PARAMS,
+      autoMinUtxo: buildAutoMinUtxo
     })
 
   const tx = await signBuilder.toTransaction()

--- a/packages/evolution/test/TxBuilder.UnfrackChangeHandling.test.ts
+++ b/packages/evolution/test/TxBuilder.UnfrackChangeHandling.test.ts
@@ -86,15 +86,16 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
       expect(tx.body.inputs).toHaveLength(2) // Initial + reselected UTxO
       expect(tx.body.outputs).toHaveLength(5) // 1 payment + 4 change (3 token bundles + 1 ADA)
 
+      // Verify payment output is correct
       const paymentOutput = tx.body.outputs[0]
-      expect(paymentOutput.assets.lovelace).toBe(969_750n)
+      expect(paymentOutput.assets.lovelace).toBe(100_000n)
 
       // Verify all change outputs meet minUTxO (corrected Babbage/Conway formula)
       const changeOutputs = tx.body.outputs.slice(1)
       expect(changeOutputs[0].assets.lovelace).toBe(1_150_770n)
       expect(changeOutputs[1].assets.lovelace).toBe(1_150_770n)
       expect(changeOutputs[2].assets.lovelace).toBe(1_155_080n)
-      expect(changeOutputs[3].assets.lovelace).toBe(1_389_737n)
+      expect(changeOutputs[3].assets.lovelace).toBe(2_259_487n)
 
       // Verify token distribution: all 3 tokens should be preserved in change outputs
       let totalTokenTypes = 0
@@ -116,7 +117,7 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
 
   describe("Immediate fallback to single output when bundles unaffordable", () => {
     it("should fall back to single change output without reselection when bundles barely unaffordable", async () => {
-      let initialAssets = CoreAssets.fromLovelace(3_000_000n)
+      let initialAssets = CoreAssets.fromLovelace(2_500_000n)
       initialAssets = CoreAssets.addByHex(initialAssets, POLICY_A, toHex("TOKEN1"), 100n)
       initialAssets = CoreAssets.addByHex(initialAssets, POLICY_B, toHex("TOKEN2"), 200n)
       initialAssets = CoreAssets.addByHex(initialAssets, POLICY_C, toHex("TOKEN3"), 300n)
@@ -124,7 +125,7 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
         transactionId: "c".repeat(64),
         index: 0,
         address: CHANGE_ADDRESS,
-        lovelace: 3_000_000n
+        lovelace: 2_500_000n
       })
       const initialUtxo = new CoreUTxO.UTxO({ ...initialUtxoBase, assets: initialAssets })
 
@@ -138,7 +139,7 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
         .collectFrom({ inputs: [initialUtxo] })
         .payToAddress({
           address: CoreAddress.fromBech32(DESTINATION_ADDRESS),
-          assets: CoreAssets.fromLovelace(1_000_000n) // Above min-ADA so no bump occurs
+          assets: CoreAssets.fromLovelace(100_000n)
         })
 
       const signBuilder = await builder.build({
@@ -161,19 +162,19 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
 
       // Verify payment output
       const paymentOutput = tx.body.outputs[0]
-      expect(paymentOutput.assets.lovelace).toBe(1_000_000n)
+      expect(paymentOutput.assets.lovelace).toBe(100_000n)
 
       // Verify change output has correct amount after fee convergence
-      // Input: 3,000,000, Payment: 1,000,000, Fee: 173,553
-      // Available change 1,826,447 < subdivideThreshold * 3 (1,500,000) → immediate single-output fallback
+      // Input: 2,500,000, Payment: 100,000, Fee: exact
+      // Expected change: 2,500,000 - 100,000 - fee
       const changeOutput = tx.body.outputs[1]
-      expect(changeOutput.assets.lovelace).toBe(1_826_447n)
+      expect(changeOutput.assets.lovelace).toBe(2_226_447n)
 
       // Verify fee is exact for single-output transaction
       expect(tx.body.fee).toBe(173_553n)
 
       // Balance equation must hold
-      expect(changeOutput.assets.lovelace + paymentOutput.assets.lovelace + tx.body.fee).toBe(3_000_000n)
+      expect(changeOutput.assets.lovelace + paymentOutput.assets.lovelace + tx.body.fee).toBe(2_500_000n)
 
       // Verify all 3 tokens are in the single change output
       let totalTokenTypes = 0
@@ -208,8 +209,7 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
           assets: CoreAssets.fromLovelace(200_000n)
         })
 
-      // With min-ADA enforcement, the 200_000n payment is bumped to ~969_750n,
-      // which exceeds the 500_000n input → coin selection fails before reaching change validation.
+      // Expect build to throw error
       await expect(async () => {
         await builder.build({
           changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
@@ -222,7 +222,7 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
             }
           }
         })
-      }).rejects.toThrow(/Coin selection failed/)
+      }).rejects.toThrow(/Native assets present/)
     })
   })
 
@@ -312,14 +312,14 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
         transactionId: "6".repeat(64),
         index: 0,
         address: CHANGE_ADDRESS,
-        lovelace: 1_500_000n
+        lovelace: 350_000n
       })
 
       const builder = makeTxBuilder({ chain: mainnet })
         .collectFrom({ inputs: [initialUtxo] })
         .payToAddress({
           address: CoreAddress.fromBech32(DESTINATION_ADDRESS),
-          assets: CoreAssets.fromLovelace(969_750n) // At min-ADA so no bump; leftover ~530k < minUTxO → drainTo fires
+          assets: CoreAssets.fromLovelace(100_000n)
         })
 
       const signBuilder = await builder.build({
@@ -349,14 +349,14 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
         transactionId: "7".repeat(64),
         index: 0,
         address: CHANGE_ADDRESS,
-        lovelace: 1_500_000n
+        lovelace: 350_000n
       })
 
       const builder = makeTxBuilder({ chain: mainnet })
         .collectFrom({ inputs: [initialUtxo] })
         .payToAddress({
           address: CoreAddress.fromBech32(DESTINATION_ADDRESS),
-          assets: CoreAssets.fromLovelace(969_750n) // At min-ADA so no bump; leftover ~530k < minUTxO → burn fires
+          assets: CoreAssets.fromLovelace(100_000n)
         })
 
       const signBuilder = await builder.build({
@@ -376,7 +376,7 @@ describe("TxBuilder: Unfrack Change Handling Integration", () => {
 
       expect(tx.body.inputs).toHaveLength(1)
       expect(tx.body.outputs).toHaveLength(1) // Only payment
-      expect(tx.body.outputs[0].assets.lovelace).toBe(969_750n) // Payment at min-ADA (leftover burned as fee)
+      expect(tx.body.outputs[0].assets.lovelace).toBe(100_000n) // Payment unchanged (leftover burned as fee)
     })
   })
 })


### PR DESCRIPTION
#311 merged auto min-UTxO enforcement that always silently bumps `payToAddress` outputs. This is dangerous for script-address outputs where validators check exact values, breaks budget determinism for batch payouts, and prevents testing error paths.

Make `autoMinUtxo` opt-in: add it to `BuildOptions` (off by default) with a per-call override on `PayToAddressParams`. Revert the `UnfrackChangeHandling` test changes since default-off restores pre-#311 behavior.