### PR TITLE
fix(devnet): auto-allocate host ports for parallel test stability

### DIFF
--- a/.changeset/devnet-auto-port-allocation.md
+++ b/.changeset/devnet-auto-port-allocation.md
@@ -1,0 +1,9 @@
+---
+"@evolution-sdk/devnet": patch
+---
+
+`Cluster.make` now auto-allocates host ports for cardano-node, Kupo, and Ogmios when not specified, so parallel test runs no longer collide on the previous fixed defaults (1442/1337/4001/8090). The returned `Cluster` exposes a new `ports` field with the assigned host ports.
+
+Consumers passing explicit `port` values on `kupo`, `ogmios`, or `ports` keep their existing behavior. Consumers that relied on the previous fixed defaults should read the assigned port from `cluster.ports.kupo`, `cluster.ports.ogmios`, `cluster.ports.node`, and `cluster.ports.submit` instead.
+
+Container starts now retry with exponential backoff to absorb transient Docker daemon pressure when many containers come up at once.

--- a/packages/evolution-devnet/src/Cluster.ts
+++ b/packages/evolution-devnet/src/Cluster.ts
@@ -2,6 +2,7 @@ import { NodeStream } from "@effect/platform-node"
 import Docker from "dockerode"
 import { Data, Effect, Stream } from "effect"
 import * as fs from "fs"
+import { createServer } from "net"
 import * as os from "os"
 import * as path from "path"
 
@@ -20,9 +21,28 @@ export interface Cluster {
   readonly kupo?: Container.Container | undefined
   readonly ogmios?: Container.Container | undefined
   readonly networkName: string
+  /** Host ports assigned to each container. */
+  readonly ports: {
+    readonly node: number
+    readonly submit: number
+    readonly kupo?: number
+    readonly ogmios?: number
+  }
   /** The Shelley genesis config used by this cluster (needed for slot config) */
   readonly shelleyGenesis: Config.ShelleyGenesis
 }
+
+const findFreePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = createServer()
+    server.unref()
+    server.on("error", reject)
+    server.listen(0, () => {
+      const addr = server.address()
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0
+      server.close(() => resolve(port))
+    })
+  })
 
 /**
  * Internal utilities for cluster operations.
@@ -93,12 +113,25 @@ const writeConfigFiles = (config: Required<Config.DevNetConfig>) =>
  */
 export const makeEffect = (config: Config.DevNetConfig = {}): Effect.Effect<Cluster, ClusterError> =>
   Effect.gen(function* () {
+    const kupoEnabled = config.kupo?.enabled ?? Config.DEFAULT_DEVNET_CONFIG.kupo.enabled
+    const ogmiosEnabled = config.ogmios?.enabled ?? Config.DEFAULT_DEVNET_CONFIG.ogmios.enabled
+    const resolvedPorts = {
+      node: config.ports?.node ?? (yield* Effect.promise(() => findFreePort())),
+      submit: config.ports?.submit ?? (yield* Effect.promise(() => findFreePort())),
+      kupo: kupoEnabled
+        ? (config.kupo?.port ?? (yield* Effect.promise(() => findFreePort())))
+        : undefined,
+      ogmios: ogmiosEnabled
+        ? (config.ogmios?.port ?? (yield* Effect.promise(() => findFreePort())))
+        : undefined
+    }
+
     const fullConfig: Required<Config.DevNetConfig> = {
       clusterName: config.clusterName ?? Config.DEFAULT_DEVNET_CONFIG.clusterName,
       image: config.image ?? Config.DEFAULT_DEVNET_CONFIG.image,
       ports: {
-        ...Config.DEFAULT_DEVNET_CONFIG.ports,
-        ...config.ports
+        node: resolvedPorts.node,
+        submit: resolvedPorts.submit
       },
       networkMagic: config.networkMagic ?? Config.DEFAULT_DEVNET_CONFIG.networkMagic,
       nodeConfig: {
@@ -135,11 +168,13 @@ export const makeEffect = (config: Config.DevNetConfig = {}): Effect.Effect<Clus
       },
       kupo: {
         ...Config.DEFAULT_DEVNET_CONFIG.kupo,
-        ...config.kupo
+        ...config.kupo,
+        ...(resolvedPorts.kupo !== undefined ? { port: resolvedPorts.kupo } : {})
       },
       ogmios: {
         ...Config.DEFAULT_DEVNET_CONFIG.ogmios,
-        ...config.ogmios
+        ...config.ogmios,
+        ...(resolvedPorts.ogmios !== undefined ? { port: resolvedPorts.ogmios } : {})
       }
     }
 
@@ -291,6 +326,7 @@ export const makeEffect = (config: Config.DevNetConfig = {}): Effect.Effect<Clus
           }
         : undefined,
       networkName,
+      ports: resolvedPorts,
       shelleyGenesis: fullConfig.shelleyGenesis as Config.ShelleyGenesis
     }
   })

--- a/packages/evolution-devnet/src/Container.ts
+++ b/packages/evolution-devnet/src/Container.ts
@@ -1,5 +1,5 @@
 import Docker from "dockerode"
-import { Data, Effect } from "effect"
+import { Data, Effect, Schedule } from "effect"
 import { PassThrough } from "stream"
 
 import * as Config from "./Config.js"
@@ -16,6 +16,10 @@ export interface Container {
   readonly name: string
 }
 
+// Docker daemon rejects concurrent container starts under load; retry transient
+// failures with exponential backoff so parallel test forks don't fail-fast.
+const startRetrySchedule = Schedule.exponential("500 millis").pipe(Schedule.compose(Schedule.recurs(3)))
+
 /**
  * Start a specific devnet container.
  *
@@ -31,7 +35,7 @@ export const startEffect = (container: Container): Effect.Effect<void, Container
         message: "Check if ports are available and Docker has sufficient resources.",
         cause
       })
-  })
+  }).pipe(Effect.retry(startRetrySchedule))
 
 /**
  * Start a specific devnet container, throws on error.

--- a/packages/evolution-devnet/test/Client.Devnet.test.ts
+++ b/packages/evolution-devnet/test/Client.Devnet.test.ts
@@ -22,7 +22,10 @@ describe("Client with Devnet", () => {
 
   const createTestClient = () =>
     Client.make(Cluster.getChain(devnetCluster!))
-      .withKupmios({ kupoUrl: "http://localhost:1443", ogmiosUrl: "http://localhost:1338" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex: 0 })
 
   beforeAll(async () => {
@@ -43,8 +46,8 @@ describe("Client with Devnet", () => {
       clusterName: "client-kupmios-wallet-test",
       ports: { node: 6001, submit: 9002 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1443, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1338, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/Client.Devnet.test.ts
+++ b/packages/evolution-devnet/test/Client.Devnet.test.ts
@@ -44,7 +44,6 @@ describe("Client with Devnet", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "client-kupmios-wallet-test",
-      ports: { node: 6001, submit: 9002 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/Devnet.Genesis.test.ts
+++ b/packages/evolution-devnet/test/Devnet.Genesis.test.ts
@@ -25,7 +25,6 @@ describe("Devnet.Genesis", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "genesis-utxo-calculation-test",
-      ports: { node: 6002, submit: 9003 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: false },
       ogmios: { enabled: false }

--- a/packages/evolution-devnet/test/TxBuilder.AddSigner.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.AddSigner.test.ts
@@ -50,7 +50,6 @@ describe("TxBuilder addSigner (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "addsigner-test",
-      ports: { node: 6007, submit: 9008 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.AddSigner.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.AddSigner.test.ts
@@ -25,7 +25,10 @@ describe("TxBuilder addSigner (Devnet Submit)", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1449", ogmiosUrl: "http://localhost:1344" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -49,8 +52,8 @@ describe("TxBuilder addSigner (Devnet Submit)", () => {
       clusterName: "addsigner-test",
       ports: { node: 6007, submit: 9008 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1449, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1344, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Chain.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Chain.test.ts
@@ -43,7 +43,6 @@ describe("TxBuilder.chainResult", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "chain-test",
-      ports: { node: 6013, submit: 9013 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Chain.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Chain.test.ts
@@ -18,7 +18,10 @@ describe("TxBuilder.chainResult", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1456", ogmiosUrl: "http://localhost:1348" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -42,8 +45,8 @@ describe("TxBuilder.chainResult", () => {
       clusterName: "chain-test",
       ports: { node: 6013, submit: 9013 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1456, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1348, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Compose.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Compose.test.ts
@@ -26,7 +26,10 @@ describe("TxBuilder compose (Devnet Submit)", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1458", ogmiosUrl: "http://localhost:1350" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -50,8 +53,8 @@ describe("TxBuilder compose (Devnet Submit)", () => {
       clusterName: "compose-test",
       ports: { node: 6015, submit: 9015 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1458, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1350, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Compose.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Compose.test.ts
@@ -51,7 +51,6 @@ describe("TxBuilder compose (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "compose-test",
-      ports: { node: 6015, submit: 9015 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Governance.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Governance.test.ts
@@ -29,7 +29,10 @@ describe("TxBuilder Governance Operations", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1457", ogmiosUrl: "http://localhost:1349" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -83,8 +86,8 @@ describe("TxBuilder Governance Operations", () => {
       ports: { node: 6014, submit: 9014 },
       shelleyGenesis: genesisConfig,
       conwayGenesis,
-      kupo: { enabled: true, port: 1457, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1349, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Governance.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Governance.test.ts
@@ -83,7 +83,6 @@ describe("TxBuilder Governance Operations", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "governance-ops-test",
-      ports: { node: 6014, submit: 9014 },
       shelleyGenesis: genesisConfig,
       conwayGenesis,
       kupo: { enabled: true, logLevel: "Info" },

--- a/packages/evolution-devnet/test/TxBuilder.Metadata.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Metadata.test.ts
@@ -25,7 +25,10 @@ describe("TxBuilder attachMetadata (Devnet Submit)", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1450", ogmiosUrl: "http://localhost:1345" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -49,8 +52,8 @@ describe("TxBuilder attachMetadata (Devnet Submit)", () => {
       clusterName: "metadata-test",
       ports: { node: 6008, submit: 9009 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1450, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1345, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Metadata.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Metadata.test.ts
@@ -50,7 +50,6 @@ describe("TxBuilder attachMetadata (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "metadata-test",
-      ports: { node: 6008, submit: 9009 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Mint.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Mint.test.ts
@@ -67,7 +67,6 @@ describe("TxBuilder Minting (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "client-minting-test",
-      ports: { node: 6001, submit: 9002 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Mint.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Mint.test.ts
@@ -31,7 +31,10 @@ describe("TxBuilder Minting (Devnet Submit)", () => {
   const createTestClient = () => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1443", ogmiosUrl: "http://localhost:1338" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex: 0 })
   }
 
@@ -66,8 +69,8 @@ describe("TxBuilder Minting (Devnet Submit)", () => {
       clusterName: "client-minting-test",
       ports: { node: 6001, submit: 9002 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1443, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1338, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.NativeScript.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.NativeScript.test.ts
@@ -67,7 +67,6 @@ describe("TxBuilder NativeScript (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "nativescript-test",
-      ports: { node: 6007, submit: 9008 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.NativeScript.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.NativeScript.test.ts
@@ -42,7 +42,10 @@ describe("TxBuilder NativeScript (Devnet Submit)", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1449", ogmiosUrl: "http://localhost:1344" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -66,8 +69,8 @@ describe("TxBuilder NativeScript (Devnet Submit)", () => {
       clusterName: "nativescript-test",
       ports: { node: 6007, submit: 9008 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1449, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1344, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.PlutusMint.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.PlutusMint.test.ts
@@ -95,7 +95,6 @@ describe("TxBuilder Plutus Minting (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "plutus-minting-test",
-      ports: { node: 6002, submit: 9003 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.PlutusMint.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.PlutusMint.test.ts
@@ -66,7 +66,10 @@ describe("TxBuilder Plutus Minting (Devnet Submit)", () => {
   const createTestClient = () => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1444", ogmiosUrl: "http://localhost:1339" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex: 0 })
   }
 
@@ -94,8 +97,8 @@ describe("TxBuilder Plutus Minting (Devnet Submit)", () => {
       clusterName: "plutus-minting-test",
       ports: { node: 6002, submit: 9003 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1444, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1339, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Pool.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Pool.test.ts
@@ -75,7 +75,6 @@ describe("TxBuilder Pool Operations", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "pool-ops-test",
-      ports: { node: 6006, submit: 9007 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Pool.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Pool.test.ts
@@ -34,7 +34,10 @@ describe("TxBuilder Pool Operations", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1453", ogmiosUrl: "http://localhost:1343" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -74,8 +77,8 @@ describe("TxBuilder Pool Operations", () => {
       clusterName: "pool-ops-test",
       ports: { node: 6006, submit: 9007 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1453, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1343, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.RedeemerBuilder.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.RedeemerBuilder.test.ts
@@ -114,7 +114,6 @@ describe("TxBuilder RedeemerBuilder", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "redeemer-builder-test",
-      ports: { node: 6003, submit: 9004 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.RedeemerBuilder.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.RedeemerBuilder.test.ts
@@ -85,7 +85,10 @@ describe("TxBuilder RedeemerBuilder", () => {
   const createTestClient = () => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1445", ogmiosUrl: "http://localhost:1340" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex: 0 })
   }
 
@@ -113,8 +116,8 @@ describe("TxBuilder RedeemerBuilder", () => {
       clusterName: "redeemer-builder-test",
       ports: { node: 6003, submit: 9004 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1445, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1340, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.ScriptStake.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.ScriptStake.test.ts
@@ -83,7 +83,10 @@ describe("TxBuilder Script Stake Operations", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1447", ogmiosUrl: "http://localhost:1342" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -111,8 +114,8 @@ describe("TxBuilder Script Stake Operations", () => {
       clusterName: "script-stake-test",
       ports: { node: 6005, submit: 9006 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1447, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1342, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.ScriptStake.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.ScriptStake.test.ts
@@ -112,7 +112,6 @@ describe("TxBuilder Script Stake Operations", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "script-stake-test",
-      ports: { node: 6005, submit: 9006 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Scripts.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Scripts.test.ts
@@ -44,7 +44,6 @@ describe("TxBuilder Script Handling", () => {
         },
         ogmios: {
           enabled: true,
-          port: 1337,
           logLevel: "info"
         }
       })
@@ -54,13 +53,12 @@ describe("TxBuilder Script Handling", () => {
       // Wait for Ogmios to be ready
       await new Promise((resolve) => setTimeout(resolve, 2_000))
 
-      // Ogmios serves both HTTP (for JSON-RPC) and WebSocket on the same port
-      const ogmiosUrl = "http://localhost:1337"
+      const ogmiosUrl = `http://localhost:${devnetCluster.ports.ogmios}`
 
       // Create provider using local Ogmios
       // Note: Kupo URL is required but not used in these tests (only Ogmios for evaluation)
       kupmiosProvider = new KupmiosProvider(
-        "http://localhost:1442", // Kupo (not used)
+        `http://localhost:${devnetCluster.ports.kupo}`, // Kupo (not used)
         ogmiosUrl // Ogmios for script evaluation via HTTP
       )
 

--- a/packages/evolution-devnet/test/TxBuilder.Scripts.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Scripts.test.ts
@@ -33,11 +33,7 @@ describe("TxBuilder Script Handling", () => {
     try {
       devnetCluster = await Cluster.make({
         clusterName: "txbuilder-plutus-script-eval",
-        ports: {
-          node: 5001,
-          submit: 9001
-        },
-        shelleyGenesis: {
+      shelleyGenesis: {
           slotLength: 0.02, // 20ms per slot (fast)
           epochLength: 50,
           activeSlotsCoeff: 1.0

--- a/packages/evolution-devnet/test/TxBuilder.SpendScriptRef.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.SpendScriptRef.test.ts
@@ -66,7 +66,6 @@ describe("TxBuilder Spend ScriptRef (Devnet Submit)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "spend-scriptref-test",
-      ports: { node: 6011, submit: 9011 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.SpendScriptRef.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.SpendScriptRef.test.ts
@@ -39,7 +39,10 @@ describe("TxBuilder Spend ScriptRef (Devnet Submit)", () => {
   const createTestClient = () => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1454", ogmiosUrl: "http://localhost:1346" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex: 0 })
   }
 
@@ -65,8 +68,8 @@ describe("TxBuilder Spend ScriptRef (Devnet Submit)", () => {
       clusterName: "spend-scriptref-test",
       ports: { node: 6011, submit: 9011 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1454, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1346, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Stake.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Stake.test.ts
@@ -37,7 +37,10 @@ describe("TxBuilder Stake Operations", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1446", ogmiosUrl: "http://localhost:1341" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -81,8 +84,8 @@ describe("TxBuilder Stake Operations", () => {
       clusterName: "stake-ops-test",
       ports: { node: 6004, submit: 9005 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1446, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1341, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Stake.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Stake.test.ts
@@ -82,7 +82,6 @@ describe("TxBuilder Stake Operations", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "stake-ops-test",
-      ports: { node: 6004, submit: 9005 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Validity.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Validity.test.ts
@@ -33,7 +33,10 @@ describe("TxBuilder Validity Interval", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1451", ogmiosUrl: "http://localhost:1351" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -58,8 +61,8 @@ describe("TxBuilder Validity Interval", () => {
       clusterName: "validity-test",
       ports: { node: 6009, submit: 9016 },
       shelleyGenesis: genesisConfig,
-      kupo: { enabled: true, port: 1451, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1351, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.Validity.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Validity.test.ts
@@ -59,7 +59,6 @@ describe("TxBuilder Validity Interval", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "validity-test",
-      ports: { node: 6009, submit: 9016 },
       shelleyGenesis: genesisConfig,
       kupo: { enabled: true, logLevel: "Info" },
       ogmios: { enabled: true, logLevel: "info" }

--- a/packages/evolution-devnet/test/TxBuilder.Vote.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Vote.test.ts
@@ -64,7 +64,9 @@ describe("TxBuilder Vote Operations (script-free)", () => {
       }
     }
 
-    conwayGenesis = Config.DEFAULT_CONWAY_GENESIS
+    // Bump govActionLifetime past the default 8 epochs so a slow CI run can finish
+    // propose → vote within the proposal's active window.
+    conwayGenesis = { ...Config.DEFAULT_CONWAY_GENESIS, govActionLifetime: 30 }
 
     const genesisUtxos = await Genesis.calculateUtxosFromConfig(genesisConfig)
 
@@ -75,7 +77,6 @@ describe("TxBuilder Vote Operations (script-free)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "vote-test",
-      ports: { node: 6010, submit: 9010 },
       shelleyGenesis: genesisConfig,
       conwayGenesis,
       kupo: { enabled: true, logLevel: "Info" },

--- a/packages/evolution-devnet/test/TxBuilder.Vote.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.Vote.test.ts
@@ -35,7 +35,10 @@ describe("TxBuilder Vote Operations (script-free)", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1453", ogmiosUrl: "http://localhost:1343" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
 
@@ -75,8 +78,8 @@ describe("TxBuilder Vote Operations (script-free)", () => {
       ports: { node: 6010, submit: 9010 },
       shelleyGenesis: genesisConfig,
       conwayGenesis,
-      kupo: { enabled: true, port: 1453, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1343, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.VoteValidators.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.VoteValidators.test.ts
@@ -52,7 +52,10 @@ describe("TxBuilder Vote Validator (script DRep)", () => {
   const createTestClient = (accountIndex: number = 0) => {
     if (!devnetCluster) throw new Error("Cluster not initialized")
     return Client.make(Cluster.getChain(devnetCluster))
-      .withKupmios({ kupoUrl: "http://localhost:1455", ogmiosUrl: "http://localhost:1347" })
+      .withKupmios({
+        kupoUrl: `http://localhost:${devnetCluster!.ports.kupo}`,
+        ogmiosUrl: `http://localhost:${devnetCluster!.ports.ogmios}`
+      })
       .withSeed({ mnemonic: TEST_MNEMONIC, accountIndex, addressType: "Base" })
   }
   const genesisUtxosByAccount: Map<number, Cardano.UTxO.UTxO> = new Map()
@@ -82,8 +85,8 @@ describe("TxBuilder Vote Validator (script DRep)", () => {
       ports: { node: 6012, submit: 9012 },
       shelleyGenesis: genesisConfig,
       conwayGenesis: { ...Config.DEFAULT_CONWAY_GENESIS, govActionLifetime: 30 },
-      kupo: { enabled: true, port: 1455, logLevel: "Info" },
-      ogmios: { enabled: true, port: 1347, logLevel: "info" }
+      kupo: { enabled: true, logLevel: "Info" },
+      ogmios: { enabled: true, logLevel: "info" }
     })
 
     await Cluster.start(devnetCluster)

--- a/packages/evolution-devnet/test/TxBuilder.VoteValidators.test.ts
+++ b/packages/evolution-devnet/test/TxBuilder.VoteValidators.test.ts
@@ -82,7 +82,6 @@ describe("TxBuilder Vote Validator (script DRep)", () => {
 
     devnetCluster = await Cluster.make({
       clusterName: "vote-validator-test",
-      ports: { node: 6012, submit: 9012 },
       shelleyGenesis: genesisConfig,
       conwayGenesis: { ...Config.DEFAULT_CONWAY_GENESIS, govActionLifetime: 30 },
       kupo: { enabled: true, logLevel: "Info" },

--- a/packages/evolution-devnet/test/globalSetup.ts
+++ b/packages/evolution-devnet/test/globalSetup.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect"
+
+import * as Config from "../src/Config.js"
+import * as Images from "../src/Images.js"
+
+const REQUIRED_IMAGES = [
+  Config.DEFAULT_DEVNET_CONFIG.image,
+  Config.DEFAULT_KUPO_CONFIG.image,
+  Config.DEFAULT_OGMIOS_CONFIG.image
+]
+
+// Pre-pull every image the integration tests need.
+// Concurrent test forks would otherwise race dockerode's image pull stream.
+export default async function setup(): Promise<void> {
+  for (const image of REQUIRED_IMAGES) {
+    await Effect.runPromise(Images.ensureAvailableEffect(image))
+  }
+}

--- a/packages/evolution-devnet/vitest.config.ts
+++ b/packages/evolution-devnet/vitest.config.ts
@@ -14,11 +14,7 @@ export default defineConfig({
     // Each test file creates its own cluster (cardano-node + kupo + ogmios).
     // Cap parallelism so total RAM stays within typical 7-8GB CI runner budget.
     pool: "forks",
-    poolOptions: {
-      forks: {
-        maxForks: 2
-      }
-    },
+    maxWorkers: 3,
     // Devnet tests are slow but should not be retried — flakiness here is a real infra failure
     retry: 0,
     exclude: ["**/node_modules/**", "**/dist/**", "**/temp/**", "**/.direnv/**", "**/.{idea,git,cache,output,temp}/**"]

--- a/packages/evolution-devnet/vitest.config.ts
+++ b/packages/evolution-devnet/vitest.config.ts
@@ -8,12 +8,15 @@ export default defineConfig({
     testTimeout: 120_000,
     hookTimeout: 90_000,
     teardownTimeout: 60_000,
-    // Serialize all test files — each file creates its own cluster (cardano-node + kupo + ogmios)
-    // Running them concurrently exhausts Docker resources on CI / local machines
+    // Pre-pull images before any test forks start, otherwise concurrent pulls of
+    // the same image race dockerode's pull stream.
+    globalSetup: ["./test/globalSetup.ts"],
+    // Each test file creates its own cluster (cardano-node + kupo + ogmios).
+    // Cap parallelism so total RAM stays within typical 7-8GB CI runner budget.
     pool: "forks",
     poolOptions: {
       forks: {
-        maxForks: 3
+        maxForks: 2
       }
     },
     // Devnet tests are slow but should not be retried — flakiness here is a real infra failure


### PR DESCRIPTION
`Cluster.make` fell back to fixed default host ports (Kupo 1442, Ogmios 1337, cardano-node 4001/8090) when the caller did not pass explicit values. On top of that, individual test files hard-coded duplicate `ports: { node, submit }` pairs (AddSigner/NativeScript both on 6007, Client.Devnet/Mint on 6001, Devnet.Genesis/PlutusMint on 6002, etc). Any run with more than one test fork in flight produced `Bind for 0.0.0.0:NNNN failed: port is already allocated`. The suite had been pinned to `singleFork: true` to hide the design issue, but that setting was itself silently ignored under vitest 4 because `poolOptions.forks.singleFork` is no longer a recognized config key.

Host ports now auto-allocate via Node's `net.createServer().listen(0)` whenever `port` is omitted on `kupo`, `ogmios`, or `ports`. The returned `Cluster` exposes the assigned ports on a new `ports` field, and all test fixtures stop hard-coding ports so each fork gets its own free port. `Container.startEffect` retries with exponential backoff for transient daemon pressure, and a vitest `globalSetup` pre-pulls the required images once before any fork starts. The vitest config is migrated from the removed `poolOptions.forks.maxForks` to top-level `maxWorkers: 3` so the setting is actually honored. The Vote test's `conwayGenesis` bumps `govActionLifetime` past the default 8 epochs so a slow propose→vote sequence does not trip `expired proposal` rejection under contention.

Full devnet suite runs green at `maxWorkers: 3` three times in a row, ~120s per run.

Closes #382