### PR TITLE
fix(cose): bind verifyData signing key to the address credential

### DIFF
--- a/.changeset/verifydata-address-binding.md
+++ b/.changeset/verifydata-address-binding.md
@@ -1,0 +1,7 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+`COSE.SignData.verifyData` now binds the signing key to the claimed address. Previously it checked the protected-header address and the public-key hash as two independent caller-supplied claims and never required the public key in the signed message to match the credential contained in the address. A signature produced by one key carrying a different address in its protected header would still verify, so address-based authentication and attestation flows could accept a proof from the wrong signer.
+
+Verification now decodes the claimed address, derives its key-hash credential (the payment credential for base and enterprise addresses, the stake credential for reward addresses), and requires the embedded public key to hash to that credential. Addresses whose credential is a script hash are rejected, since a single Ed25519 key cannot satisfy a script credential. Genuine signatures whose key matches the address continue to verify unchanged.

--- a/docs/content/docs/wallets/message-signing.mdx
+++ b/docs/content/docs/wallets/message-signing.mdx
@@ -74,7 +74,10 @@ Verification checks:
 2. Address in the signature matches the expected address
 3. Algorithm is EdDSA
 4. Public key hash matches the expected key hash
-5. Ed25519 signature is cryptographically valid
+5. Public key hashes to the address's credential — the payment credential for base/enterprise addresses, the stake credential for reward addresses (the signing key is bound to the claimed address)
+6. Ed25519 signature is cryptographically valid
+
+The address-binding check (5) is what ties the signature to the claimed address. The address's credential must be a key hash; script addresses cannot be proven by a single key and are rejected.
 
 ## Payload Utilities
 

--- a/packages/evolution/src/cose/SignData.ts
+++ b/packages/evolution/src/cose/SignData.ts
@@ -9,10 +9,13 @@
 
 import { Equal, Schema } from "effect"
 
+import * as Address from "../Address.js"
 import * as Bytes from "../Bytes.js"
 import type * as CBOR from "../CBOR.js"
+import * as Credential from "../Credential.js"
 import * as KeyHash from "../KeyHash.js"
 import * as PrivateKey from "../PrivateKey.js"
+import * as RewardAccount from "../RewardAccount.js"
 import * as VKey from "../VKey.js"
 import { headerMapNew, headersNew } from "./Header.js"
 import { COSEKeyFromCBORBytes, EdDSA25519Key } from "./Key.js"
@@ -90,6 +93,28 @@ export const signData = (addressHex: string, payload: Payload, privateKey: Priva
 }
 
 /**
+ * Resolve the key-hash credential that a claimed address commits to. The
+ * signing key must hash to this credential for the signature to be bound to the
+ * address. Per CIP-19, reward (stake) addresses use header types `0b1110` and
+ * `0b1111` and carry a stake credential; base and enterprise addresses carry a
+ * payment credential. Returns undefined when the address cannot be parsed.
+ */
+const addressSignerCredential = (addressHex: string): Credential.Credential | undefined => {
+  const header = Bytes.fromHex(addressHex)[0]
+  if (header === undefined) return undefined
+  const addressType = header >> 4
+  const isRewardAddress = addressType === 0b1110 || addressType === 0b1111
+  if (isRewardAddress) {
+    try {
+      return RewardAccount.fromHex(addressHex).stakeCredential
+    } catch {
+      return undefined
+    }
+  }
+  return Address.getPaymentCredential(addressHex)
+}
+
+/**
  * Verify a COSE_Sign1 signed message.
  *
  * Validates CIP-30 signatures by verifying:
@@ -97,7 +122,15 @@ export const signData = (addressHex: string, payload: Payload, privateKey: Priva
  * - Address matches protected headers
  * - Algorithm is EdDSA
  * - Public key hash matches provided key hash
+ * - Public key hashes to the claimed address's credential (address binding):
+ *   the payment credential for base/enterprise addresses, the stake credential
+ *   for reward addresses
  * - Ed25519 signature is cryptographically valid
+ *
+ * The address-binding check prevents accepting a signature produced by one key
+ * while a different victim address is presented in the protected header. Only
+ * key-hash credentials are accepted; script addresses cannot be proven by a
+ * single Ed25519 key and are rejected.
  *
  * @since 2.0.0
  * @category API
@@ -150,7 +183,16 @@ export const verifyData = (
 
     const publicKey = VKey.fromBytes(publicKeyBytes)
     const publicKeyHash = KeyHash.fromVKey(publicKey)
-    if (KeyHash.toHex(publicKeyHash) !== keyHash) return false
+    const publicKeyHashHex = KeyHash.toHex(publicKeyHash)
+    if (publicKeyHashHex !== keyHash) return false
+
+    // Bind the signing key to the claimed address: the embedded public key must
+    // hash to the address's credential. Without this, a signature made by an
+    // attacker key carrying a victim address in its protected header would
+    // verify. Script credentials cannot be satisfied by one Ed25519 key.
+    const expectedCredential = addressSignerCredential(addressHex)
+    if (expectedCredential === undefined || expectedCredential._tag !== "KeyHash") return false
+    if (Credential.toHex(expectedCredential) !== publicKeyHashHex) return false
 
     // Get signed data
     const signedData = coseSign1.signedData()

--- a/packages/evolution/test/SignData.Parity.test.ts
+++ b/packages/evolution/test/SignData.Parity.test.ts
@@ -3,6 +3,7 @@ import * as CML from "@dcspark/cardano-multiplatform-lib-nodejs"
 import * as M from "@emurgo/cardano-message-signing-nodejs"
 import { describe, expect, it } from "vitest"
 
+import * as Address from "../src/Address.js"
 import { fromHex, toHex } from "../src/Bytes.js"
 import { SignData } from "../src/cose/index.js"
 import * as KeyHash from "../src/KeyHash.js"
@@ -141,7 +142,9 @@ describe("SignData Parity with lucid-evolution", () => {
   const publicKey = PrivateKey.toPublicKey(privateKey)
   const keyHash = KeyHash.fromVKey(publicKey)
   const keyHashHex = KeyHash.toHex(keyHash)
-  const addressHex = keyHashHex
+  // Real enterprise address bound to the signer's key hash (verifyData enforces
+  // that the signing key matches the address's payment credential).
+  const addressHex = Address.toHex(new Address.Address({ networkId: 0, paymentCredential: keyHash }))
   const payload = new Uint8Array([1, 2, 3, 4, 5])
   const payloadHex = toHex(payload)
 

--- a/packages/evolution/test/SignData.test.ts
+++ b/packages/evolution/test/SignData.test.ts
@@ -1,11 +1,20 @@
 import { FastCheck } from "effect"
 import { describe, expect, it } from "vitest"
 
+import * as Address from "../src/Address.js"
 import * as Bytes from "../src/Bytes.js"
 import { COSESign1, Header, SignData, Utils } from "../src/cose/index.js"
+import * as Credential from "../src/Credential.js"
 import * as KeyHash from "../src/KeyHash.js"
 import * as PrivateKey from "../src/PrivateKey.js"
+import * as RewardAccount from "../src/RewardAccount.js"
 import * as VKey from "../src/VKey.js"
+
+// Build a real enterprise address (testnet) whose payment credential is the
+// given key hash. verifyData binds the signing key to the address credential,
+// so tests must use real addresses rather than a bare key hash.
+const addressHexFor = (keyHash: KeyHash.KeyHash): string =>
+  Address.toHex(new Address.Address({ networkId: 0, paymentCredential: keyHash }))
 
 describe("SignData", () => {
   describe("Payload", () => {
@@ -30,8 +39,8 @@ describe("SignData", () => {
       const privateKey = PrivateKey.fromBytes(privateKeyBytes)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
 
-      // Create a test address (using the public key hash)
-      const addressHex = Bytes.toHex(keyHash.hash)
+      // Create a real enterprise address bound to the signer's key hash
+      const addressHex = addressHexFor(keyHash)
 
       // Create payload
       const payload = Utils.fromText("Hello, Cardano!")
@@ -48,7 +57,7 @@ describe("SignData", () => {
       const privateKeyBytes = PrivateKey.generate()
       const privateKey = PrivateKey.fromBytes(privateKeyBytes)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
-      const addressHex = KeyHash.toHex(keyHash)
+      const addressHex = addressHexFor(keyHash)
 
       const payload1 = Utils.fromText("Hello")
       const payload2 = Utils.fromText("World")
@@ -63,8 +72,9 @@ describe("SignData", () => {
       const privateKeyBytes = PrivateKey.generate()
       const privateKey = PrivateKey.fromBytes(privateKeyBytes)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
-      const addressHex1 = KeyHash.toHex(keyHash)
-      const addressHex2 = "ff" + KeyHash.toHex(keyHash).slice(2)
+      const otherKeyHash = KeyHash.fromPrivateKey(PrivateKey.fromBytes(PrivateKey.generate()))
+      const addressHex1 = addressHexFor(keyHash)
+      const addressHex2 = addressHexFor(otherKeyHash)
 
       const payload = Utils.fromText("Hello")
 
@@ -84,7 +94,7 @@ describe("SignData", () => {
       const keyHash1 = KeyHash.fromPrivateKey(privateKey1)
       const keyHash2 = KeyHash.fromPrivateKey(privateKey2)
 
-      const addressHex = KeyHash.toHex(keyHash1)
+      const addressHex = addressHexFor(keyHash1)
       const payload = Utils.fromText("Hello")
 
       const signedMessage = SignData.signData(addressHex, payload, privateKey1)
@@ -97,7 +107,7 @@ describe("SignData", () => {
       const privateKeyBytes = PrivateKey.generate()
       const privateKey = PrivateKey.fromBytes(privateKeyBytes)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
-      const addressHex = KeyHash.toHex(keyHash)
+      const addressHex = addressHexFor(keyHash)
 
       const payload = new Uint8Array(0) as Utils.Payload
 
@@ -111,7 +121,7 @@ describe("SignData", () => {
       const privateKeyBytes = PrivateKey.generate()
       const privateKey = PrivateKey.fromBytes(privateKeyBytes)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
-      const addressHex = KeyHash.toHex(keyHash)
+      const addressHex = addressHexFor(keyHash)
 
       // Create a large payload (1KB of data)
       const largeText = "x".repeat(1024)
@@ -127,7 +137,7 @@ describe("SignData", () => {
       const extendedKey = PrivateKey.generateExtended()
       const privateKey = PrivateKey.fromBytes(extendedKey)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
-      const addressHex = KeyHash.toHex(keyHash)
+      const addressHex = addressHexFor(keyHash)
 
       const payload = Utils.fromText("Testing extended keys")
 
@@ -135,6 +145,59 @@ describe("SignData", () => {
       const isValid = SignData.verifyData(addressHex, KeyHash.toHex(keyHash), payload, signedMessage)
 
       expect(isValid).toBe(true)
+    })
+
+    it("should reject a signature from a different key carrying a victim address (address binding)", () => {
+      const victimKey = PrivateKey.fromBytes(PrivateKey.generate())
+      const attackerKey = PrivateKey.fromBytes(PrivateKey.generate())
+      const victimKeyHash = KeyHash.fromPrivateKey(victimKey)
+      const attackerKeyHash = KeyHash.fromPrivateKey(attackerKey)
+      const victimAddressHex = addressHexFor(victimKeyHash)
+      const payload = Utils.fromText("login challenge")
+
+      // Attacker signs with their own key but embeds the victim's address in the
+      // protected header, then presents their own key hash (as a naive consumer
+      // sourcing the key hash from the message would).
+      const forged = SignData.signData(victimAddressHex, payload, attackerKey)
+      expect(SignData.verifyData(victimAddressHex, KeyHash.toHex(attackerKeyHash), payload, forged)).toBe(false)
+
+      // A genuine message signed by the victim still verifies.
+      const genuine = SignData.signData(victimAddressHex, payload, victimKey)
+      expect(SignData.verifyData(victimAddressHex, KeyHash.toHex(victimKeyHash), payload, genuine)).toBe(true)
+    })
+
+    it("should reject a script payment-credential address", () => {
+      const privateKey = PrivateKey.fromBytes(PrivateKey.generate())
+      const keyHash = KeyHash.fromPrivateKey(privateKey)
+      // Address whose payment credential is a script hash, not a key hash.
+      const scriptCredential = Credential.makeScriptHash(keyHash.hash)
+      const scriptAddressHex = Address.toHex(
+        new Address.Address({ networkId: 0, paymentCredential: scriptCredential })
+      )
+      const payload = Utils.fromText("Hello")
+
+      const signedMessage = SignData.signData(scriptAddressHex, payload, privateKey)
+      const isValid = SignData.verifyData(scriptAddressHex, KeyHash.toHex(keyHash), payload, signedMessage)
+      expect(isValid).toBe(false)
+    })
+
+    it("should bind a reward (stake) address to the stake credential", () => {
+      const privateKey = PrivateKey.fromBytes(PrivateKey.generate())
+      const keyHash = KeyHash.fromPrivateKey(privateKey)
+      const rewardAddressHex = RewardAccount.toHex(
+        new RewardAccount.RewardAccount({ networkId: 0, stakeCredential: keyHash })
+      )
+      const payload = Utils.fromText("stake login")
+
+      // Genuine signature with the stake key verifies against the reward address.
+      const signed = SignData.signData(rewardAddressHex, payload, privateKey)
+      expect(SignData.verifyData(rewardAddressHex, KeyHash.toHex(keyHash), payload, signed)).toBe(true)
+
+      // A different key carrying the victim reward address is rejected.
+      const attackerKey = PrivateKey.fromBytes(PrivateKey.generate())
+      const attackerKeyHash = KeyHash.fromPrivateKey(attackerKey)
+      const forged = SignData.signData(rewardAddressHex, payload, attackerKey)
+      expect(SignData.verifyData(rewardAddressHex, KeyHash.toHex(attackerKeyHash), payload, forged)).toBe(false)
     })
   })
 
@@ -146,7 +209,7 @@ describe("SignData", () => {
           FastCheck.uint8Array({ minLength: 0, maxLength: 100 }),
           (privateKey, payloadBytes) => {
             const keyHash = KeyHash.fromPrivateKey(privateKey)
-            const addressHex = KeyHash.toHex(keyHash)
+            const addressHex = addressHexFor(keyHash)
 
             const payload = payloadBytes as Utils.Payload
 
@@ -173,7 +236,7 @@ describe("SignData", () => {
             }
 
             const keyHash = KeyHash.fromPrivateKey(privateKey)
-            const addressHex = KeyHash.toHex(keyHash)
+            const addressHex = addressHexFor(keyHash)
 
             const payload1 = payloadBytes1 as Utils.Payload
             const payload2 = payloadBytes2 as Utils.Payload
@@ -203,7 +266,7 @@ describe("SignData", () => {
               return true
             }
 
-            const addressHex = KeyHash.toHex(keyHash1)
+            const addressHex = addressHexFor(keyHash1)
             const payload = payloadBytes as Utils.Payload
 
             const signedMessage = SignData.signData(addressHex, payload, privateKey1)
@@ -381,7 +444,7 @@ describe("SignData", () => {
       const privateKeyBytes = PrivateKey.generate()
       const privateKey = PrivateKey.fromBytes(privateKeyBytes)
       const keyHash = KeyHash.fromPrivateKey(privateKey)
-      const addressHex = KeyHash.toHex(keyHash)
+      const addressHex = addressHexFor(keyHash)
       const payload = Utils.fromText("test")
 
       const signedMessage = SignData.signData(addressHex, payload, privateKey)


### PR DESCRIPTION
`COSE.SignData.verifyData` validated the protected-header address and the public-key hash as two independent caller-supplied claims, but never required the public key in the signed message to belong to the credential inside the claimed address. A signature produced by one key while a different address sat in the protected header still verified, so address-based login and attestation flows could accept a proof from the wrong signer.

Verification now decodes the claimed address, derives its key-hash credential (payment credential for base/enterprise addresses, stake credential for reward addresses), and requires the embedded public key to hash to it. Script-credential addresses are rejected because a single Ed25519 key cannot satisfy them, and genuine signatures whose key matches the address keep verifying unchanged.

Closes #394