### PR TITLE
fix(crypto): use constant-time scalar multiplication for secret keys

### DIFF
--- a/.changeset/constant-time-secret-scalar.md
+++ b/.changeset/constant-time-secret-scalar.md
@@ -1,0 +1,7 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Key derivation and signing now use constant-time scalar multiplication for secret key material. Several call sites that derive a public key from a secret scalar used a variable-time base-point multiplication whose execution time depends on the secret, leaking information through a timing side channel. The affected paths were private-key public-key derivation, extended-key signing, verification-key derivation, and the BIP32 child derivation, public-key, and 128-byte export/import paths.
+
+These sites now use the constant-time multiplication that was already in use for the per-signature nonce. Results are identical for valid keys, so derived public keys and signatures are unchanged; an all-zero scalar (only reachable from an invalid imported key) now raises an error instead of returning a degenerate point.

--- a/packages/evolution/src/Bip32PrivateKey.ts
+++ b/packages/evolution/src/Bip32PrivateKey.ts
@@ -305,7 +305,8 @@ export namespace Either {
       } else {
         // 0x02 || publicKey || index
         const scalarBigInt = mod(bytesToNumberLE(scalar), ed25519.Point.Fn.ORDER)
-        const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+        // Constant-time multiply: the scalar is secret key material
+        const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
         const publicKey = publicKeyPoint.toBytes()
         zInput = new Uint8Array(1 + 32 + 4)
         zInput.set(zTag, 0)
@@ -334,7 +335,8 @@ export namespace Either {
       } else {
         // 0x03 || publicKey || index (use parent public key)
         const scalarBigInt = mod(bytesToNumberLE(scalar), ed25519.Point.Fn.ORDER)
-        const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+        // Constant-time multiply: the scalar is secret key material
+        const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
         const publicKey = publicKeyPoint.toBytes()
         ccInput = new Uint8Array(1 + 32 + 4)
         ccInput.set(ccTag, 0)
@@ -404,7 +406,8 @@ export namespace Either {
       const publicKeyBytes = yield* Effect.try({
         try: () => {
           const scalarBigInt = mod(bytesToNumberLE(scalar), ed25519.Point.Fn.ORDER)
-          const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+          // Constant-time multiply: the scalar is secret key material
+          const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
           return publicKeyPoint.toBytes()
         },
         catch: (cause) => new Bip32PrivateKeyError({ message: "toPublicKey failed", cause })
@@ -427,7 +430,8 @@ export namespace Either {
       const publicKeyBytes = yield* Effect.try({
         try: () => {
           const scalarBigInt = mod(bytesToNumberLE(scalar), ed25519.Point.Fn.ORDER)
-          const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+          // Constant-time multiply: the scalar is secret key material
+          const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
           return publicKeyPoint.toBytes()
         },
         catch: (cause) => new Bip32PrivateKeyError({ message: "to_128_xprv failed", cause })
@@ -455,7 +459,8 @@ export namespace Either {
       const derivedPK = yield* Effect.try({
         try: () => {
           const scalarBigInt = mod(bytesToNumberLE(scalar), ed25519.Point.Fn.ORDER)
-          const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+          // Constant-time multiply: the scalar is secret key material
+          const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
           return publicKeyPoint.toBytes()
         },
         catch: (cause) => new Bip32PrivateKeyError({ message: "from_128_xprv failed", cause })

--- a/packages/evolution/src/PrivateKey.ts
+++ b/packages/evolution/src/PrivateKey.ts
@@ -442,7 +442,8 @@ export namespace Either {
         // Calculate public key from scalar: publicKey = scalar * G
         // Apply modular reduction to ensure scalar is in valid range [0, curve.n)
         const scalarBigInt = mod(bytesToNumberLE(scalar), CURVE_ORDER)
-        const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+        // Constant-time multiply: the scalar is secret key material
+        const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
         const publicKey = publicKeyPoint.toBytes()
 
         // Calculate nonce: nonce = reduce(sha512(iv || message))

--- a/packages/evolution/src/VKey.ts
+++ b/packages/evolution/src/VKey.ts
@@ -137,7 +137,8 @@ export const fromPrivateKey = (privateKey: PrivateKey.PrivateKey): VKey => {
     const scalar = privateKeyBytes.slice(0, 32)
     // Apply modular reduction to ensure scalar is in valid range [0, curve.n)
     const scalarBigInt = mod(bytesToNumberLE(scalar), ed25519.Point.Fn.ORDER)
-    const publicKeyPoint = ed25519.Point.BASE.multiplyUnsafe(scalarBigInt)
+    // Constant-time multiply: the scalar is secret key material
+    const publicKeyPoint = ed25519.Point.BASE.multiply(scalarBigInt)
     publicKeyBytes = publicKeyPoint.toBytes()
   } else {
     // Standard 32-byte Ed25519 private key: derive public key

--- a/packages/evolution/test/ConstantTimeScalar.test.ts
+++ b/packages/evolution/test/ConstantTimeScalar.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { ed25519 } from "@noble/curves/ed25519.js"
+import { describe, expect, it } from "vitest"
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..", "src")
+
+// Files whose Point.BASE multiplications operate on secret key scalars. These
+// must use the constant-time `multiply`, never the variable-time
+// `multiplyUnsafe`, so the operation timing does not depend on the secret.
+const SECRET_SCALAR_FILES = ["PrivateKey.ts", "VKey.ts", "Bip32PrivateKey.ts"]
+
+describe("constant-time secret scalar multiplication", () => {
+  it.each(SECRET_SCALAR_FILES)("%s must not use multiplyUnsafe on secret scalars", (file) => {
+    const source = readFileSync(join(srcDir, file), "utf8")
+    expect(source).not.toContain("multiplyUnsafe")
+  })
+
+  it("multiply and multiplyUnsafe produce identical points for a valid scalar", () => {
+    // The swap must not change results for valid (non-zero) scalars.
+    const scalar = 0x1cca3b06f9b9b8f0e2b3a1d4c5e6f70819283746556473829100aabbccddeeffn % ed25519.Point.Fn.ORDER
+    const constantTime = ed25519.Point.BASE.multiply(scalar).toBytes()
+    const variableTime = ed25519.Point.BASE.multiplyUnsafe(scalar).toBytes()
+    expect(constantTime).toEqual(variableTime)
+  })
+})


### PR DESCRIPTION
Several key-derivation and signing paths multiplied the base point by a secret scalar using a variable-time routine whose execution time depends on the secret. That leaks information about private key material through a timing side channel, even though the constant-time routine was already used for the per-signature nonce in the same code.

The secret-scalar sites (private-key and verification-key public-key derivation, extended-key signing, and the BIP32 child-derivation, public-key, and 128-byte export/import paths) now use the constant-time multiplication. Results are identical for valid keys, so derived public keys and signatures are unchanged; an all-zero scalar, reachable only from an invalid imported key, now raises instead of returning a degenerate point. The public-scalar site is intentionally left as-is.

Closes #392