### PR TITLE
fix(address): validate CIP-19 header type bits and bech32 prefix

### DIFF
--- a/.changeset/address-header-validation.md
+++ b/.changeset/address-header-validation.md
@@ -1,0 +1,7 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Address parsing now validates the CIP-19 header type, not just the byte length. Previously `Address.fromHex` and `Address.fromBech32` chose between a base address and an enterprise address by length alone and never checked the header type nibble. A 29-byte reward (stake) address has the same length as an enterprise address, so it was accepted as an enterprise address with its stake credential silently used as the payment credential. `fromBech32` also ignored the bech32 prefix, so a `stake1...` string parsed as a payment address.
+
+Parsing now requires header type 0–3 on the 57-byte base branch and 6–7 on the 29-byte enterprise branch, rejecting reward, pointer, Byron, and reserved types; the same check is applied in `BaseAddress.FromBytes` and `EnterpriseAddress.FromBytes`. `fromBech32` now requires an `addr`/`addr_test` prefix that agrees with the network in the header. Reward and stake addresses are handled by `RewardAccount`, not `Address`.

--- a/packages/evolution/src/Address.ts
+++ b/packages/evolution/src/Address.ts
@@ -104,7 +104,12 @@ export const FromBytes = Schema.transformOrFail(
         const addressTypeBits = (header >> 4) & 0b1111
 
         if (fromA.length === 57) {
-          // BaseAddress (with staking credential)
+          // BaseAddress (with staking credential): CIP-19 header types 0-3
+          if (addressTypeBits > 0b0011) {
+            return yield* ParseResult.fail(
+              new ParseResult.Type(ast, fromA, `Invalid base address type: ${addressTypeBits}`)
+            )
+          }
           const isPaymentKey = (addressTypeBits & 0b0001) === 0
           const paymentCredential: Credential.Credential = isPaymentKey
             ? new KeyHash.KeyHash({ hash: fromA.slice(1, 29) })
@@ -121,7 +126,12 @@ export const FromBytes = Schema.transformOrFail(
             stakingCredential
           })
         } else if (fromA.length === 29) {
-          // EnterpriseAddress (no staking credential)
+          // EnterpriseAddress (no staking credential): CIP-19 header types 6-7
+          if (addressTypeBits !== 0b0110 && addressTypeBits !== 0b0111) {
+            return yield* ParseResult.fail(
+              new ParseResult.Type(ast, fromA, `Invalid enterprise address type: ${addressTypeBits}`)
+            )
+          }
           const isPaymentKey = (addressTypeBits & 0b0001) === 0
           const paymentCredential: Credential.Credential = isPaymentKey
             ? new KeyHash.KeyHash({ hash: fromA.slice(1, 29) })
@@ -168,17 +178,28 @@ export const FromBech32 = Schema.transformOrFail(Schema.String, Schema.typeSchem
     }),
   decode: (fromA, _, ast) =>
     Eff.gen(function* () {
-      const result = yield* Eff.try({
+      const decoded = yield* Eff.try({
         try: () => {
           // Note: `as any` needed because bech32.decode expects template literal type `${Prefix}1${string}`
           // but Schema provides plain string. Consider using decodeToBytes which accepts string.
-          const decoded = bech32.decode(fromA as any, false)
-          const bytes = bech32.fromWords(decoded.words)
-          return new Uint8Array(bytes)
+          const result = bech32.decode(fromA as any, false)
+          return { prefix: result.prefix, bytes: new Uint8Array(bech32.fromWords(result.words)) }
         },
         catch: () => new ParseResult.Type(ast, fromA, `Failed to decode Bech32: ${fromA}`)
       })
-      return yield* ParseResult.decode(FromBytes)(result)
+      // Reject non-payment prefixes (e.g. stake / stake_test reward addresses)
+      if (decoded.prefix !== "addr" && decoded.prefix !== "addr_test") {
+        return yield* ParseResult.fail(new ParseResult.Type(ast, fromA, `Invalid address prefix: ${decoded.prefix}`))
+      }
+      const address = yield* ParseResult.decode(FromBytes)(decoded.bytes)
+      // Prefix must agree with the network in the header (testnet -> addr_test)
+      const expectedPrefix = address.networkId === 0 ? "addr_test" : "addr"
+      if (decoded.prefix !== expectedPrefix) {
+        return yield* ParseResult.fail(
+          new ParseResult.Type(ast, fromA, `Prefix ${decoded.prefix} does not match network ${address.networkId}`)
+        )
+      }
+      return address
     })
 }).annotations({
   identifier: "AddressStructure.FromBech32",

--- a/packages/evolution/src/BaseAddress.ts
+++ b/packages/evolution/src/BaseAddress.ts
@@ -69,6 +69,10 @@ export const FromBytes = Schema.transformOrFail(
         const networkId = header & 0b00001111
         // Extract address type from the upper 4 bits (bits 4-7)
         const addressType = header >> 4
+        // Base addresses are CIP-19 header types 0-3
+        if (addressType > 0b0011) {
+          return yield* ParseResult.fail(new ParseResult.Type(ast, fromA, `Invalid base address type: ${addressType}`))
+        }
         // Script payment, Script stake
         const isPaymentKey = (addressType & 0b0001) === 0
         const paymentCredential: Credential.Credential = isPaymentKey

--- a/packages/evolution/src/EnterpriseAddress.ts
+++ b/packages/evolution/src/EnterpriseAddress.ts
@@ -63,13 +63,20 @@ export const FromBytes = Schema.transformOrFail(
 
         return yield* ParseResult.succeed(result)
       }),
-    decode: (_, __, ___, fromA) =>
+    decode: (_, __, ast, fromA) =>
       Eff.gen(function* () {
         const header = fromA[0]
         // Extract network ID from the lower 4 bits
         const networkId = header & 0b00001111
         // Extract address type from the upper 4 bits (bits 4-7)
         const addressType = header >> 4
+
+        // Enterprise addresses are CIP-19 header types 6-7
+        if (addressType !== 0b0110 && addressType !== 0b0111) {
+          return yield* ParseResult.fail(
+            new ParseResult.Type(ast, fromA, `Invalid enterprise address type: ${addressType}`)
+          )
+        }
 
         // Script payment
         const isPaymentKey = (addressType & 0b0001) === 0

--- a/packages/evolution/test/Address.HeaderValidation.test.ts
+++ b/packages/evolution/test/Address.HeaderValidation.test.ts
@@ -1,0 +1,58 @@
+import { bech32 } from "@scure/base"
+import { describe, expect, it } from "vitest"
+
+import * as Address from "../src/Address.js"
+import * as Bytes from "../src/Bytes.js"
+import * as KeyHash from "../src/KeyHash.js"
+import * as PrivateKey from "../src/PrivateKey.js"
+import * as RewardAccount from "../src/RewardAccount.js"
+
+describe("Address header validation (CIP-19)", () => {
+  const keyHash = KeyHash.fromPrivateKey(PrivateKey.fromBytes(PrivateKey.generate()))
+
+  it("rejects a reward address supplied as hex (was parsed as Enterprise)", () => {
+    const reward = new RewardAccount.RewardAccount({ networkId: 1, stakeCredential: keyHash })
+    const rewardHex = RewardAccount.toHex(reward)
+    // sanity: 0xe1 = reward, stake-key, mainnet — same 29-byte length as Enterprise
+    expect(rewardHex.slice(0, 2)).toBe("e1")
+    expect(() => Address.fromHex(rewardHex)).toThrow()
+  })
+
+  it("rejects a stake1... bech32 string", () => {
+    const reward = new RewardAccount.RewardAccount({ networkId: 1, stakeCredential: keyHash })
+    const stakeBech32 = RewardAccount.toBech32(reward)
+    expect(stakeBech32.startsWith("stake1")).toBe(true)
+    expect(() => Address.fromBech32(stakeBech32)).toThrow()
+  })
+
+  it("rejects a bech32 prefix that disagrees with the network", () => {
+    // Testnet enterprise payload (networkId 0) encoded under the mainnet "addr" prefix
+    const enterprise = new Address.Address({ networkId: 0, paymentCredential: keyHash })
+    const mislabeled = bech32.encode("addr", bech32.toWords(Address.toBytes(enterprise)), false)
+    expect(() => Address.fromBech32(mislabeled)).toThrow()
+  })
+
+  it("rejects a non-enterprise type in the 29-byte branch", () => {
+    // 0x41 = type 4 (pointer), mainnet — must not be accepted as Enterprise
+    const pointerHex = "41" + Bytes.toHex(keyHash.hash)
+    expect(() => Address.fromHex(pointerHex)).toThrow()
+  })
+
+  it("still parses a valid enterprise address round-trip", () => {
+    const enterprise = new Address.Address({ networkId: 0, paymentCredential: keyHash })
+    const parsed = Address.fromHex(Address.toHex(enterprise))
+    expect(parsed.paymentCredential._tag).toBe("KeyHash")
+    expect(parsed.stakingCredential).toBeUndefined()
+
+    const bech = Address.toBech32(enterprise)
+    expect(bech.startsWith("addr_test1")).toBe(true)
+    expect(Address.fromBech32(bech).networkId).toBe(0)
+  })
+
+  it("still parses a valid base address round-trip", () => {
+    const base = new Address.Address({ networkId: 1, paymentCredential: keyHash, stakingCredential: keyHash })
+    const parsed = Address.fromHex(Address.toHex(base))
+    expect(parsed.paymentCredential._tag).toBe("KeyHash")
+    expect(parsed.stakingCredential?._tag).toBe("KeyHash")
+  })
+})


### PR DESCRIPTION
`Address.fromHex` and `Address.fromBech32` selected between a base and an enterprise address by byte length alone and never validated the CIP-19 header type. A 29-byte reward (stake) address has the same length as an enterprise address, so it was accepted as an enterprise address with the stake credential silently used as the payment credential, and `fromBech32` discarded the prefix so a `stake1...` string parsed as a payment address.

Parsing now validates the header type nibble: types 0-3 on the 57-byte base branch and 6-7 on the 29-byte enterprise branch, rejecting reward, pointer, Byron, and reserved types, with the same check added to `BaseAddress.FromBytes` and `EnterpriseAddress.FromBytes`. `fromBech32` now requires an `addr`/`addr_test` prefix that agrees with the network in the header. Reward and stake addresses belong to `RewardAccount`, not `Address`.

Closes #391