### PR TITLE
fix(cose): honor the CIP-8 hashed flag in verifyData

### DIFF
--- a/.changeset/cose-honor-hashed-flag.md
+++ b/.changeset/cose-honor-hashed-flag.md
@@ -1,0 +1,7 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+`COSE.SignData.verifyData` now honors the CIP-8 `hashed` flag. When a signer hashes a large message, the flag is set and the signed payload is the blake2b-224 digest of the message rather than the message itself. Verification previously ignored the flag and always compared the supplied payload to the signed bytes literally, so a hashed message from a wallet could never be verified against its original payload. Verification now reads the flag and, when set, compares the blake2b-224 digest of the supplied payload, matching the message-signing reference used by browser wallets.
+
+The flag is intentionally left in the unprotected headers to preserve byte-for-byte compatibility with that reference, where the flag also lives in the unprotected map; `signData` output is unchanged.

--- a/packages/evolution/src/cose/SignData.ts
+++ b/packages/evolution/src/cose/SignData.ts
@@ -7,6 +7,7 @@
  * @category Sign Data
  */
 
+import { blake2b } from "@noble/hashes/blake2.js"
 import { Equal, Schema } from "effect"
 
 import * as Bytes from "../Bytes.js"
@@ -93,7 +94,8 @@ export const signData = (addressHex: string, payload: Payload, privateKey: Priva
  * Verify a COSE_Sign1 signed message.
  *
  * Validates CIP-30 signatures by verifying:
- * - Payload matches signed data
+ * - Payload matches signed data (honoring the CIP-8 `hashed` flag: when set, the
+ *   signed payload is the blake2b-224 digest of the message)
  * - Address matches protected headers
  * - Algorithm is EdDSA
  * - Public key hash matches provided key hash
@@ -114,7 +116,20 @@ export const verifyData = (
 
     // Verify payload matches (allow empty payloads)
     if (coseSign1.payload === undefined) return false
-    if (!Bytes.equals(coseSign1.payload, payload)) return false
+    // Honor the CIP-8 "hashed" flag. cardano-message-signing writes it to the
+    // unprotected headers and, when set, signs the blake2b-224 digest of the
+    // message rather than the message itself. Match that so hashed messages from
+    // CIP-30 wallets verify against the original payload.
+    const hashedLabel = labelFromText("hashed")
+    let payloadHashed = false
+    for (const [label, value] of coseSign1.headers.unprotected.headers.entries()) {
+      if (Equal.equals(label, hashedLabel)) {
+        payloadHashed = value === true
+        break
+      }
+    }
+    const expectedPayload = payloadHashed ? blake2b(payload, { dkLen: 28 }) : payload
+    if (!Bytes.equals(coseSign1.payload, expectedPayload)) return false
 
     // Get protected headers
     const addressLabel = labelFromText("address")

--- a/packages/evolution/test/SignData.Parity.test.ts
+++ b/packages/evolution/test/SignData.Parity.test.ts
@@ -240,4 +240,37 @@ describe("SignData Parity with lucid-evolution", () => {
     }
     expect(verifyData(wrongKeyHash, keyHashHex, payloadHex, lucidFormat)).toBe(false)
   })
+
+  it("verifies a hashed message produced by cardano-message-signing", () => {
+    const message = new TextEncoder().encode("a long message that a wallet chooses to hash before signing")
+
+    // Build a hashed COSE_Sign1 with the reference library: hash_payload sets the
+    // hashed flag in the unprotected headers and signs blake2b-224 of the message.
+    const protectedHeaders = M.HeaderMap.new()
+    protectedHeaders.set_algorithm_id(M.Label.from_algorithm_id(M.AlgorithmId.EdDSA))
+    protectedHeaders.set_header(M.Label.new_text("address"), M.CBORValue.new_bytes(fromHex(addressHex)))
+    const headers = M.Headers.new(M.ProtectedHeaderMap.new(protectedHeaders), M.HeaderMap.new())
+    const builder = M.COSESign1Builder.new(headers, message, false)
+    builder.hash_payload()
+    const toSign = builder.make_data_to_sign().to_bytes()
+    const priv = CML.PrivateKey.from_bech32(privateKeyBech32)
+    const coseSign1 = builder.build(priv.sign(toSign).to_raw_bytes())
+
+    const key = M.COSEKey.new(M.Label.from_key_type(M.KeyType.OKP))
+    key.set_algorithm_id(M.Label.from_algorithm_id(M.AlgorithmId.EdDSA))
+    key.set_header(M.Label.new_int(M.Int.new_negative(M.BigNum.from_str("1"))), M.CBORValue.new_int(M.Int.new_i32(6)))
+    key.set_header(
+      M.Label.new_int(M.Int.new_negative(M.BigNum.from_str("2"))),
+      M.CBORValue.new_bytes(priv.to_public().to_raw_bytes())
+    )
+
+    const ourFormat = { key: key.to_bytes(), signature: coseSign1.to_bytes() }
+
+    // verifyData honors the hashed flag and verifies against the original message
+    expect(SignData.verifyData(addressHex, keyHashHex, message, ourFormat)).toBe(true)
+    // a different preimage must fail
+    expect(SignData.verifyData(addressHex, keyHashHex, new TextEncoder().encode("different message"), ourFormat)).toBe(
+      false
+    )
+  })
 })


### PR DESCRIPTION
When a signer hashes a large message before signing, the CIP-8 `hashed` flag is set and the signed payload is the blake2b-224 digest of the message, not the message itself. `verifyData` ignored the flag and always compared the supplied payload to the signed bytes literally, so a hashed message from a browser wallet could never be verified against its original payload.

`verifyData` now reads the `hashed` flag and, when set, compares the blake2b-224 digest of the supplied payload. The flag is intentionally kept in the unprotected headers: the message-signing reference that browser wallets use places it there too, so moving it into the signed headers would break byte-for-byte compatibility and cross-wallet verification. `signData` output is unchanged and the byte-identical parity test still passes.

Closes #393