### PR TITLE
fix(cose): route signMessage through COSE_Sign1 domain separation

### DIFF
--- a/.changeset/signmessage-domain-separation.md
+++ b/.changeset/signmessage-domain-separation.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+The seed/private-key wallet's `signMessage` now signs through a COSE_Sign1 structure instead of signing the caller's bytes directly. Previously it signed the raw payload with the same key and primitive used for transactions, so passing a 32-byte transaction body hash produced a valid transaction witness — making `signMessage` usable as a transaction-signing oracle. The signed bytes are now domain-separated by the COSE `Sig_structure` (the "Signature1" context plus the address in the protected headers), so they can never be a bare transaction witness. The result's `signature` is the COSE_Sign1, matching the format already returned by the CIP-30 wallet path.

--- a/packages/evolution/src/sdk/client/internal/Signing.ts
+++ b/packages/evolution/src/sdk/client/internal/Signing.ts
@@ -1,7 +1,8 @@
 import { Effect, Equal, ParseResult, Schema } from "effect"
 
+import * as CoreAddress from "../../../Address.js"
 import * as Bytes from "../../../Bytes.js"
-import * as Ed25519Signature from "../../../Ed25519Signature.js"
+import { SignData } from "../../../cose/index.js"
 import { runEffectPromise } from "../../../EffectRuntime.js"
 import * as KeyHash from "../../../KeyHash.js"
 import type * as NativeScripts from "../../../NativeScripts.js"
@@ -366,9 +367,17 @@ export const makeSigningWalletEffect = (
         const signingKey = useStakeKey
           ? PrivateKey.fromBech32(derivation.stakeKey!)
           : PrivateKey.fromBech32(derivation.paymentKey)
-        const bytes = typeof payload === "string" ? new TextEncoder().encode(payload) : payload
-        const signature = PrivateKey.sign(signingKey, bytes)
-        return { payload, signature: Ed25519Signature.toHex(signature) }
+        const addressHex =
+          typeof address === "string"
+            ? CoreRewardAccount.toHex(CoreRewardAccount.fromBech32(address))
+            : CoreAddress.toHex(address)
+        const payloadBytes = typeof payload === "string" ? new TextEncoder().encode(payload) : payload
+        // Domain-separate via COSE_Sign1: the Sig_structure ("Signature1" context
+        // plus the address in the protected headers) is what gets signed, so the
+        // bytes can never be a bare transaction-body hash / VKey witness. Return
+        // the COSE_Sign1 hex, matching the CIP-30 wallet path.
+        const signed = SignData.signData(addressHex, payloadBytes, signingKey)
+        return { payload, signature: Bytes.toHex(signed.signature) }
       })
   }
 

--- a/packages/evolution/test/SignMessage.DomainSeparation.test.ts
+++ b/packages/evolution/test/SignMessage.DomainSeparation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import * as Bytes from "../src/Bytes.js"
+import { COSESign1 } from "../src/cose/index.js"
+import * as PrivateKey from "../src/PrivateKey.js"
+import { preprod } from "../src/sdk/client/Chain.js"
+import { seedWallet } from "../src/sdk/client/internal/Wallets.js"
+import { keysFromSeed } from "../src/sdk/wallet/Derivation.js"
+import * as VKey from "../src/VKey.js"
+
+const mnemonic =
+  "zebra short room flavor rival capital fortune hip profit trust melody office depend adapt visa cycle february link tornado whisper physical kiwi film voyage"
+
+describe("signMessage domain separation (#389)", () => {
+  it("produces a COSE_Sign1, not a bare witness over the raw payload", async () => {
+    const wallet = seedWallet({ mnemonic })(preprod)
+    const address = await wallet.address()
+    const paymentVKey = VKey.fromPrivateKey(PrivateKey.fromBech32(keysFromSeed(mnemonic).paymentKey))
+
+    // A 32-byte value that looks like a transaction body hash
+    const txBodyHash = new Uint8Array(32).fill(0xab)
+
+    const result = await wallet.signMessage(address, txBodyHash)
+    const signatureBytes = Bytes.fromHex(result.signature)
+
+    // The signed output is a COSE_Sign1 (domain-separated), not a 64-byte signature
+    const cose = COSESign1.coseSign1FromCBORBytes(signatureBytes)
+    expect(cose.payload !== undefined && Bytes.equals(cose.payload, txBodyHash)).toBe(true)
+
+    // Oracle closed: the signature does NOT verify as a witness over the raw hash
+    expect(VKey.verify(paymentVKey, txBodyHash, cose.signature.bytes)).toBe(false)
+
+    // But it IS a valid signature over the COSE Sig_structure
+    expect(VKey.verify(paymentVKey, cose.signedData(), cose.signature.bytes)).toBe(true)
+  })
+})


### PR DESCRIPTION
The seed/private-key wallet `signMessage` signed the caller payload directly with `PrivateKey.sign`, using the same key and primitive as transaction signing and with no COSE wrapping. Passing a 32-byte transaction body hash therefore produced a valid VKeyWitness for that transaction, so `signMessage` could be used as a transaction-signing oracle.

`signMessage` now signs through the existing COSE_Sign1 implementation, so the bytes that get signed are the COSE `Sig_structure` ("Signature1" context plus the address in the protected headers) rather than the raw payload. The signed bytes can no longer be a bare transaction witness, and the returned `signature` is a COSE_Sign1 — the same format the CIP-30 wallet path already returns.

Closes #389