### PR TITLE
feat(client): read typed UTxOs from CIP-30 wallets

### DIFF
--- a/.changeset/cip30-get-utxos.md
+++ b/.changeset/cip30-get-utxos.md
@@ -1,0 +1,7 @@
+---
+"@evolution-sdk/evolution": minor
+---
+
+CIP-30 wallets can now provide typed UTxOs directly, without going through a provider. The API wallet exposes `getUtxos()` returning parsed `UTxO` values, and a new `Codegen`-free helper `cip30UtxoFromCBORHex` converts a single CIP-30 UTxO (the CBOR of a `[transaction_input, transaction_output]` pair) into a `UTxO`. Previously the only built-in source of wallet UTxOs was the provider (`getWalletUtxos` resolved the address and queried `provider.getUtxos`), so consumers had to parse the wallet's CBOR themselves.
+
+Transaction building and `getWalletUtxos` now prefer the wallet's own UTxOs when the wallet is a CIP-30 wallet, falling back to the provider for seed and private-key wallets. This reflects the wallet's own view, including UTxOs created by transactions it has just submitted, so chained transactions no longer wait for a provider to index them. A provider is still required for protocol parameters during build, since CIP-30 does not expose them.

--- a/.changeset/cip30-get-utxos.md
+++ b/.changeset/cip30-get-utxos.md
@@ -1,5 +1,5 @@
 ---
-"@evolution-sdk/evolution": minor
+"@evolution-sdk/evolution": patch
 ---
 
 CIP-30 wallets can now provide typed UTxOs directly, without going through a provider. The API wallet exposes `getUtxos()` returning parsed `UTxO` values, and a new `Codegen`-free helper `cip30UtxoFromCBORHex` converts a single CIP-30 UTxO (the CBOR of a `[transaction_input, transaction_output]` pair) into a `UTxO`. Previously the only built-in source of wallet UTxOs was the provider (`getWalletUtxos` resolved the address and queried `provider.getUtxos`), so consumers had to parse the wallet's CBOR themselves.

--- a/docs/content/docs/wallets/api-wallet.mdx
+++ b/docs/content/docs/wallets/api-wallet.mdx
@@ -80,6 +80,36 @@ async function signAndSubmit() {
 }
 ```
 
+## Reading Wallet UTxOs
+
+CIP-30 wallets expose their own UTxOs, so you can read them directly from the wallet rather than querying a provider by address. The raw CIP-30 `getUtxos()` returns each UTxO as the CBOR of a `[transaction_input, transaction_output]` pair; the client parses these into typed `UTxO` values for you.
+
+```typescript twoslash
+import { mainnet, Client } from "@evolution-sdk/evolution"
+
+declare const walletApi: any
+
+const client = Client.make(mainnet)
+  .withBlockfrost({
+    baseUrl: "https://cardano-mainnet.blockfrost.io/api/v0",
+    projectId: process.env.BLOCKFROST_API_KEY!
+  })
+  .withCip30(walletApi)
+
+// Typed UTxOs sourced from the wallet (not the provider)
+const utxos = await client.getWalletUtxos()
+```
+
+When you build with a CIP-30 wallet, coin selection draws from the wallet's own UTxOs as well. Because the wallet tracks UTxOs created by transactions it just submitted, chained transactions see the previous transaction's change immediately, without waiting for a provider to index it:
+
+```typescript
+// Build, sign, and submit tx1 through the wallet, then build tx2.
+// tx2's coin selection sees tx1's change UTxO from the wallet right away.
+const tx2 = await client.newTx().payToAddress({ address, assets }).build()
+```
+
+A provider is still required for protocol parameters during `build()` — CIP-30 does not expose them. Pass them explicitly via `build({ fullProtocolParameters })` only if you have no provider.
+
 ## Configuration Options
 
 ```typescript twoslash

--- a/packages/evolution/src/sdk/builders/internal/resolve.ts
+++ b/packages/evolution/src/sdk/builders/internal/resolve.ts
@@ -136,6 +136,12 @@ export const resolveAvailableUtxos = (
 
   const wallet = config.wallet
   const provider = config.provider
+  // CIP-30 wallets expose their own UTxOs; prefer them so the build reflects the
+  // wallet's view (including UTxOs from transactions it just submitted/chained)
+  // and so no provider is required.
+  if (wallet !== undefined && wallet.type === "api") {
+    return wallet.effect.getUtxos()
+  }
   if (wallet !== undefined && provider !== undefined) {
     return Effect.flatMap(wallet.effect.address(), (address) => provider.effect.getUtxos(address))
   }

--- a/packages/evolution/src/sdk/client/internal/Client.ts
+++ b/packages/evolution/src/sdk/client/internal/Client.ts
@@ -107,7 +107,12 @@ const createSigningClient = (
     signMessage: wallet.effect.signMessage,
     signTx: (txOrHex, context) => Signing.signWithAutoFetch(provider, wallet, txOrHex, context),
     signTxs: (txs, context) => Signing.signTxsWithAutoFetch(provider, wallet, txs, context),
-    getWalletUtxos: () => Effect.flatMap(wallet.effect.address(), (address) => provider.effect.getUtxos(address)),
+    // Prefer a CIP-30 wallet's own UTxOs (reflects its view, incl. just-submitted
+    // chained UTxOs); fall back to the provider for seed/private-key wallets.
+    getWalletUtxos: () =>
+      wallet.type === "api"
+        ? wallet.effect.getUtxos()
+        : Effect.flatMap(wallet.effect.address(), (address) => provider.effect.getUtxos(address)),
     getWalletDelegation: () =>
       Effect.flatMap(wallet.effect.rewardAddress(), (rewardAddress) => {
         if (!rewardAddress) {

--- a/packages/evolution/src/sdk/client/internal/Wallets.ts
+++ b/packages/evolution/src/sdk/client/internal/Wallets.ts
@@ -1,13 +1,19 @@
 import { Effect, ParseResult, Schema } from "effect"
 
 import * as CoreAddress from "../../../Address.js"
+import * as AddressEras from "../../../AddressEras.js"
+import * as Assets from "../../../Assets.js"
+import * as CBOR from "../../../CBOR.js"
 import { runEffectPromise } from "../../../EffectRuntime.js"
 import * as CoreRewardAccount from "../../../RewardAccount.js"
 import * as CoreRewardAddress from "../../../RewardAddress.js"
+import * as Script from "../../../Script.js"
 import * as Transaction from "../../../Transaction.js"
 import * as TransactionHash from "../../../TransactionHash.js"
+import * as TransactionInput from "../../../TransactionInput.js"
+import * as TransactionOutput from "../../../TransactionOutput.js"
 import * as TransactionWitnessSet from "../../../TransactionWitnessSet.js"
-import type * as CoreUTxO from "../../../UTxO.js"
+import * as CoreUTxO from "../../../UTxO.js"
 import * as Derivation from "../../wallet/Derivation.js"
 import * as Wallet from "../../wallet/Wallet.js"
 import type { Chain } from "../Chain.js"
@@ -142,6 +148,46 @@ export const privateKeyWallet =
  * @since 2.1.0
  * @category constructors
  */
+/**
+ * Convert a single CIP-30 UTxO (the CBOR hex of a `[transaction_input,
+ * transaction_output]` pair) into a typed core UTxO.
+ */
+export const cip30UtxoFromCBORHex = (hex: string): CoreUTxO.UTxO => {
+  const decoded = CBOR.fromCBORHex(hex)
+  if (!Array.isArray(decoded) || decoded.length !== 2) {
+    throw new Error(`Unexpected CIP-30 UTxO CBOR shape: ${hex}`)
+  }
+  const input = TransactionInput.fromCBORBytes(CBOR.toCBORBytes(decoded[0]))
+  const output = TransactionOutput.fromCBORBytes(CBOR.toCBORBytes(decoded[1]))
+
+  // The output address is era-tagged (AddressEras); UTxO uses AddressStructure.
+  // The bytes are identical, so convert by re-decoding them.
+  const address = Schema.decodeSync(CoreAddress.FromBytes)(Schema.encodeSync(AddressEras.FromBytes)(output.address))
+
+  const amount = output.amount
+  const assets =
+    amount._tag === "WithAssets"
+      ? Assets.withMultiAsset(amount.coin, amount.assets)
+      : Assets.fromLovelace(amount.coin)
+
+  // Babbage outputs carry datumOption + scriptRef; legacy Shelley outputs a datumHash
+  // (which is itself a valid DatumOption).
+  const datumOption = output._tag === "BabbageTransactionOutput" ? output.datumOption : output.datumHash
+  const scriptRef =
+    output._tag === "BabbageTransactionOutput" && output.scriptRef
+      ? Script.fromCBOR(output.scriptRef.bytes)
+      : undefined
+
+  return new CoreUTxO.UTxO({
+    transactionId: input.transactionId,
+    index: input.index,
+    address,
+    assets,
+    datumOption,
+    scriptRef
+  })
+}
+
 export const cip30Wallet =
   (api: Wallet.WalletApi) =>
   (chain: Chain): Wallet.ApiWallet => {
@@ -271,6 +317,17 @@ export const cip30Wallet =
           catch: (cause) => new Wallet.WalletError({ message: (cause as Error).message, cause: cause as Error })
         })
         return Schema.decodeSync(TransactionHash.FromHex)(txHashHex)
+      }),
+    getUtxos: () =>
+      Effect.gen(function* () {
+        const hexes = yield* Effect.tryPromise({
+          try: () => api.getUtxos(),
+          catch: (cause) => new Wallet.WalletError({ message: "Failed to fetch wallet UTxOs", cause: cause as Error })
+        })
+        return yield* Effect.try({
+          try: () => (hexes ?? []).map(cip30UtxoFromCBORHex),
+          catch: (cause) => new Wallet.WalletError({ message: "Failed to parse wallet UTxOs", cause: cause as Error })
+        })
       })
   }
 
@@ -283,6 +340,7 @@ export const cip30Wallet =
     signTxs: (txs, context) => runEffectPromise(effectInterface.signTxs(txs, context)),
     signMessage: (address, payload) => runEffectPromise(effectInterface.signMessage(address, payload)),
     submitTx: (txOrHex) => runEffectPromise(effectInterface.submitTx(txOrHex)),
+    getUtxos: () => runEffectPromise(effectInterface.getUtxos()),
     effect: effectInterface
   }
 }

--- a/packages/evolution/src/sdk/wallet/Wallet.ts
+++ b/packages/evolution/src/sdk/wallet/Wallet.ts
@@ -194,6 +194,14 @@ export interface ApiWalletEffect extends ReadOnlyWalletEffect {
   readonly submitTx: (
     tx: Transaction.Transaction | string
   ) => Effect.Effect<TransactionHash.TransactionHash, WalletError>
+  /**
+   * Fetch the wallet's available UTxOs (CIP-30 `getUtxos`) parsed into typed UTxOs.
+   * Reflects the wallet's own view, including UTxOs created by transactions the wallet
+   * has submitted, which an external provider may not have indexed yet.
+   *
+   * @since 2.3.0
+   */
+  readonly getUtxos: () => Effect.Effect<ReadonlyArray<CoreUTxO.UTxO>, WalletError>
 }
 
 /**

--- a/packages/evolution/test/Cip30GetUtxos.test.ts
+++ b/packages/evolution/test/Cip30GetUtxos.test.ts
@@ -1,0 +1,131 @@
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+
+import * as CoreAddress from "../src/Address.js"
+import * as AddressEras from "../src/AddressEras.js"
+import * as AssetName from "../src/AssetName.js"
+import * as Bytes from "../src/Bytes.js"
+import * as CBOR from "../src/CBOR.js"
+import * as DatumHash from "../src/DatumHash.js"
+import * as KeyHash from "../src/KeyHash.js"
+import * as MultiAsset from "../src/MultiAsset.js"
+import * as PolicyId from "../src/PolicyId.js"
+import * as PrivateKey from "../src/PrivateKey.js"
+import { resolveAvailableUtxos } from "../src/sdk/builders/internal/resolve.js"
+import { preprod } from "../src/sdk/client/Chain.js"
+import { cip30UtxoFromCBORHex, cip30Wallet } from "../src/sdk/client/internal/Wallets.js"
+import type * as Wallet from "../src/sdk/wallet/Wallet.js"
+import * as TransactionHash from "../src/TransactionHash.js"
+import * as TransactionInput from "../src/TransactionInput.js"
+import * as TransactionOutput from "../src/TransactionOutput.js"
+import * as Value from "../src/Value.js"
+
+// Build a real enterprise (testnet) address bound to a fresh key.
+const keyHash = KeyHash.fromPrivateKey(PrivateKey.fromBytes(PrivateKey.generate()))
+const addressHex = CoreAddress.toHex(new CoreAddress.Address({ networkId: 0, paymentCredential: keyHash }))
+const addressEras = AddressEras.fromHex(addressHex)
+
+// Build a CIP-30 UTxO: CBOR hex of [transaction_input, transaction_output].
+const makeCip30UtxoHex = (amount: Value.Value, index: bigint): string => {
+  const input = new TransactionInput.TransactionInput(
+    { transactionId: TransactionHash.fromHex("aa".repeat(32)), index },
+    { disableValidation: true }
+  )
+  const output = new TransactionOutput.BabbageTransactionOutput(
+    { address: addressEras, amount },
+    { disableValidation: true }
+  )
+  const inputCBOR = CBOR.fromCBORBytes(TransactionInput.toCBORBytes(input))
+  const outputCBOR = CBOR.fromCBORBytes(TransactionOutput.toCBORBytes(output))
+  return Bytes.toHex(CBOR.toCBORBytes([inputCBOR, outputCBOR]))
+}
+
+describe("CIP-30 getUtxos (#414)", () => {
+  it("parses a CIP-30 UTxO hex into a typed UTxO", () => {
+    const utxo = cip30UtxoFromCBORHex(makeCip30UtxoHex(Value.onlyCoin(5_000_000n), 1n))
+    expect(TransactionHash.toHex(utxo.transactionId)).toBe("aa".repeat(32))
+    expect(utxo.index).toBe(1n)
+    expect(CoreAddress.toHex(utxo.address)).toBe(addressHex)
+    expect(utxo.assets.lovelace).toBe(5_000_000n)
+    expect(utxo.datumOption).toBeUndefined()
+    expect(utxo.scriptRef).toBeUndefined()
+  })
+
+  it("getUtxos parses every UTxO the CIP-30 api returns", async () => {
+    const hexes = [makeCip30UtxoHex(Value.onlyCoin(2_000_000n), 0n), makeCip30UtxoHex(Value.onlyCoin(7_000_000n), 1n)]
+    const api = { getUtxos: () => Promise.resolve(hexes) } as unknown as Wallet.WalletApi
+    const wallet = cip30Wallet(api)(preprod)
+
+    const utxos = await wallet.getUtxos()
+    expect(utxos).toHaveLength(2)
+    expect(utxos.map((u) => u.assets.lovelace).sort()).toEqual([2_000_000n, 7_000_000n])
+  })
+
+  it("getUtxos returns an empty array when the wallet has no UTxOs", async () => {
+    const api = { getUtxos: () => Promise.resolve(undefined) } as unknown as Wallet.WalletApi
+    const wallet = cip30Wallet(api)(preprod)
+    expect(await wallet.getUtxos()).toEqual([])
+  })
+
+  it("the builder resolves UTxOs from a CIP-30 wallet with no provider", async () => {
+    const api = {
+      getUtxos: () => Promise.resolve([makeCip30UtxoHex(Value.onlyCoin(9_000_000n), 0n)])
+    } as unknown as Wallet.WalletApi
+    const wallet = cip30Wallet(api)(preprod)
+
+    // No provider in the config — the builder must source UTxOs from the wallet.
+    const utxos = await Effect.runPromise(resolveAvailableUtxos({ wallet }))
+    expect(utxos).toHaveLength(1)
+    expect(utxos[0].assets.lovelace).toBe(9_000_000n)
+  })
+
+  it("parses a real-world CIP-30 UTxO fixture (from cardano-js-sdk)", () => {
+    // Real TransactionUnspentOutput CBOR from input-output-hk/cardano-js-sdk fixtures:
+    // base address, 4,027,026,465 lovelace, two native assets, no datum/script.
+    const realHex =
+      "82825820bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e00182583900287a7e37219128cfb05322626daa8b19d1ad37c6779d21853f7b94177c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8821af0078c21a2581c1ec85dcee27f2d90ec1f9a1e4ce74a667dc9be8b184463223f9c9601a14350584c05581c659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba82a14454534c410a"
+    const utxo = cip30UtxoFromCBORHex(realHex)
+    expect(TransactionHash.toHex(utxo.transactionId)).toBe("bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0")
+    expect(utxo.index).toBe(1n)
+    expect(utxo.assets.lovelace).toBe(4_027_026_465n)
+    // base address (payment + staking) parsed
+    expect(utxo.address.stakingCredential).toBeDefined()
+    // two native asset policies present
+    expect(utxo.assets.multiAsset).toBeDefined()
+    expect(MultiAsset.getPolicyIds(utxo.assets.multiAsset!).length).toBe(2)
+    expect(utxo.datumOption).toBeUndefined()
+    expect(utxo.scriptRef).toBeUndefined()
+  })
+
+  it("preserves a realistic wallet UTxO: base address (with staking), native assets, datum hash", () => {
+    const stakeKeyHash = KeyHash.fromPrivateKey(PrivateKey.fromBytes(PrivateKey.generate()))
+    const baseAddressHex = CoreAddress.toHex(
+      new CoreAddress.Address({ networkId: 0, paymentCredential: keyHash, stakingCredential: stakeKeyHash })
+    )
+    const policyId = PolicyId.fromHex("bb".repeat(28))
+    const assetName = AssetName.fromHex("cafe")
+    const value = Value.withAssets(3_000_000n, MultiAsset.singleton(policyId, assetName, 42n))
+    const datumHash = DatumHash.fromHex("dd".repeat(32))
+
+    const input = new TransactionInput.TransactionInput(
+      { transactionId: TransactionHash.fromHex("aa".repeat(32)), index: 0n },
+      { disableValidation: true }
+    )
+    const output = new TransactionOutput.BabbageTransactionOutput(
+      { address: AddressEras.fromHex(baseAddressHex), amount: value, datumOption: datumHash },
+      { disableValidation: true }
+    )
+    const inputCBOR = CBOR.fromCBORBytes(TransactionInput.toCBORBytes(input))
+    const outputCBOR = CBOR.fromCBORBytes(TransactionOutput.toCBORBytes(output))
+    const utxoHex = Bytes.toHex(CBOR.toCBORBytes([inputCBOR, outputCBOR]))
+
+    const utxo = cip30UtxoFromCBORHex(utxoHex)
+    // Full base address (payment + staking credential) is preserved
+    expect(CoreAddress.toHex(utxo.address)).toBe(baseAddressHex)
+    expect(utxo.address.stakingCredential).toBeDefined()
+    // Lovelace + native asset preserved
+    expect(utxo.assets.lovelace).toBe(3_000_000n)
+    // Datum hash preserved as a DatumHash datum option
+    expect(utxo.datumOption?._tag).toBe("DatumHash")
+  })
+})


### PR DESCRIPTION
Retrieving wallet UTxOs only worked through a provider: `getWalletUtxos` resolved the wallet address and queried `provider.getUtxos`, and there was no typed way to read the wallet's own UTxOs. Consumers had to hand-parse the CIP-30 CBOR themselves, and a provider was effectively required even though a CIP-30 wallet already exposes its UTxOs.

This adds `getUtxos()` to the CIP-30 wallet (returning typed `UTxO[]`) plus an exported `cip30UtxoFromCBORHex` helper, and makes transaction building and `getWalletUtxos` prefer the wallet's own UTxOs when the wallet is CIP-30, falling back to the provider for seed/private-key wallets. Because the wallet reflects UTxOs from transactions it just submitted, chained transactions no longer wait for a provider to index them. A provider is still needed for protocol parameters during build, which CIP-30 does not expose.

Verified the parser against a real `TransactionUnspentOutput` fixture from input-output-hk/cardano-js-sdk (base address with staking, native assets) in addition to constructed cases.

Closes #414