### PR TITLE
fix(txbuilder): allow native-script DRep voters to vote without a red…

### DIFF
--- a/.changeset/native-script-drep-vote.md
+++ b/.changeset/native-script-drep-vote.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+`TxBuilder.vote()` no longer requires a Plutus redeemer for native-script (multisig) voters. A native-script DRep or constitutional-committee voter is satisfied by vkey witnesses, not a redeemer, so previously such a vote could not be built even though it is ledger-valid. The native-vs-Plutus distinction is now made at build time, once the voter's script is attached or referenced: a redeemer is required only for Plutus-script voters, and a redeemer supplied for a native-script voter is pruned with a warning. The fee continues to be sized for the script's threshold number of vkey witnesses.

--- a/packages/evolution/src/sdk/builders/internal/build.ts
+++ b/packages/evolution/src/sdk/builders/internal/build.ts
@@ -166,6 +166,8 @@ export const makeBuild = (
   Effect.gen(function* () {
     yield* Effect.all(programs, { concurrency: "unbounded" })
 
+    yield* TxBuilderImpl.validateVoterRedeemers
+
     const { transaction, txWithFakeWitnesses } = yield* phaseStateMachine
 
     return yield* assembleFinalResult(transaction, txWithFakeWitnesses)

--- a/packages/evolution/src/sdk/builders/internal/txBuilder.ts
+++ b/packages/evolution/src/sdk/builders/internal/txBuilder.ts
@@ -23,6 +23,7 @@ import * as Redeemers from "../../../Redeemers.js"
 import type * as RewardAccount from "../../../RewardAccount.js"
 import * as CoreScript from "../../../Script.js"
 import * as ScriptDataHash from "../../../ScriptDataHash.js"
+import * as ScriptHash from "../../../ScriptHash.js"
 import * as ScriptRef from "../../../ScriptRef.js"
 import * as Time from "../../../Time.js"
 import * as Transaction from "../../../Transaction.js"
@@ -33,6 +34,7 @@ import * as TransactionWitnessSet from "../../../TransactionWitnessSet.js"
 import * as TxOut from "../../../TxOut.js"
 import * as CoreUTxO from "../../../UTxO.js"
 import * as VKey from "../../../VKey.js"
+import type * as VotingProcedures from "../../../VotingProcedures.js"
 import * as Withdrawals from "../../../Withdrawals.js"
 import {
   BuildOptionsTag,
@@ -263,6 +265,99 @@ export const makeTxOutput = (params: {
  * @category assembly
  */
 export const buildTransactionInputs = CoreUTxO.toInputs
+
+/**
+ * Resolve the script hash (as hex) backing a script-controlled voter, or `undefined`
+ * for key-hash voters.
+ */
+const voterScriptHashHex = (voter: VotingProcedures.Voter): string | undefined => {
+  switch (voter._tag) {
+    case "ConstitutionalCommitteeVoter":
+      return voter.credential._tag === "ScriptHash" ? ScriptHash.toHex(voter.credential) : undefined
+    case "DRepVoter":
+      return voter.drep._tag === "ScriptHashDRep" ? ScriptHash.toHex(voter.drep.scriptHash) : undefined
+    case "StakePoolVoter":
+      return undefined
+  }
+}
+
+/**
+ * Validate redeemer requirements for governance voters, distinguishing native-script
+ * voters (satisfied by vkey witnesses) from Plutus-script voters (which require a redeemer).
+ *
+ * @since 2.0.0
+ * @category validation
+ */
+export const validateVoterRedeemers: Effect.Effect<void, TransactionBuilderError, TxContext> = Effect.gen(
+  function* () {
+    const stateRef = yield* TxContext
+    const state = yield* Ref.get(stateRef)
+
+    if (!state.votingProcedures || state.votingProcedures.procedures.size === 0) {
+      return
+    }
+
+    // Resolve whether the script for a given hash is native.
+    const isNativeScript = (scriptHashHex: string): boolean | undefined => {
+      const attached = state.scripts.get(scriptHashHex)
+      if (attached) return attached._tag === "NativeScript"
+
+      for (const ref of state.referenceInputs) {
+        if (ref.scriptRef && ScriptHash.toHex(ScriptHash.fromScript(ref.scriptRef)) === scriptHashHex) {
+          return ref.scriptRef._tag === "NativeScript"
+        }
+      }
+      return undefined
+    }
+
+    const plutusVotersMissingRedeemer: Array<string> = []
+    const nativeVoterRedeemerKeys: Array<string> = []
+
+    for (const voter of state.votingProcedures.procedures.keys()) {
+      const scriptHashHex = voterScriptHashHex(voter)
+      if (scriptHashHex === undefined) continue 
+
+      const voterKey = voterToKey(voter)
+      const hasRedeemer = state.redeemers.has(voterKey) || state.deferredRedeemers.has(voterKey)
+      const native = isNativeScript(scriptHashHex)
+
+      if (native === true) {
+        if (hasRedeemer) nativeVoterRedeemerKeys.push(voterKey)
+      } else {
+        if (!hasRedeemer) plutusVotersMissingRedeemer.push(voterKey)
+      }
+    }
+
+    if (plutusVotersMissingRedeemer.length > 0) {
+      return yield* Effect.fail(
+        new TransactionBuilderError({
+          message:
+            `Redeemer required for ${plutusVotersMissingRedeemer.length} Plutus-script voter(s): ` +
+            `${plutusVotersMissingRedeemer.join(", ")}. ` +
+            `Native-script voters do not need a redeemer — attach the native script via .attachScript() ` +
+            `(or provide it through a reference input) so it can be classified correctly.`,
+          cause: plutusVotersMissingRedeemer
+        })
+      )
+    }
+
+    if (nativeVoterRedeemerKeys.length > 0) {
+      yield* Effect.logWarning(
+        `[Vote] Ignoring redeemer(s) supplied for native-script voter(s): ${nativeVoterRedeemerKeys.join(", ")}. ` +
+          `Native scripts are satisfied by vkey witnesses, not redeemers.`
+      )
+      yield* Ref.update(stateRef, (s) => {
+        const redeemers = new Map(s.redeemers)
+        const deferredRedeemers = new Map(s.deferredRedeemers)
+        for (const key of nativeVoterRedeemerKeys) {
+          redeemers.delete(key)
+          deferredRedeemers.delete(key)
+        }
+        return { ...s, redeemers, deferredRedeemers }
+      })
+    }
+  }
+)
 
 /**
  * Assemble a Transaction from inputs, outputs, and calculated fee.

--- a/packages/evolution/src/sdk/builders/internal/txBuilder.ts
+++ b/packages/evolution/src/sdk/builders/internal/txBuilder.ts
@@ -334,7 +334,7 @@ export const validateVoterRedeemers: Effect.Effect<void, TransactionBuilderError
           message:
             `Redeemer required for ${plutusVotersMissingRedeemer.length} Plutus-script voter(s): ` +
             `${plutusVotersMissingRedeemer.join(", ")}. ` +
-            `Native-script voters do not need a redeemer — attach the native script via .attachScript() ` +
+            `Native-script voters do not need a redeemer. Attach the native script via .attachScript() ` +
             `(or provide it through a reference input) so it can be classified correctly.`,
           cause: plutusVotersMissingRedeemer
         })

--- a/packages/evolution/src/sdk/builders/internal/txBuilder.ts
+++ b/packages/evolution/src/sdk/builders/internal/txBuilder.ts
@@ -310,7 +310,7 @@ export const validateVoterRedeemers: Effect.Effect<void, TransactionBuilderError
       return undefined
     }
 
-    const plutusVotersMissingRedeemer: Array<string> = []
+    const votersMissingRedeemer: Array<string> = []
     const nativeVoterRedeemerKeys: Array<string> = []
 
     for (const voter of state.votingProcedures.procedures.keys()) {
@@ -324,19 +324,20 @@ export const validateVoterRedeemers: Effect.Effect<void, TransactionBuilderError
       if (native === true) {
         if (hasRedeemer) nativeVoterRedeemerKeys.push(voterKey)
       } else {
-        if (!hasRedeemer) plutusVotersMissingRedeemer.push(voterKey)
+        if (!hasRedeemer) votersMissingRedeemer.push(voterKey)
       }
     }
 
-    if (plutusVotersMissingRedeemer.length > 0) {
+    if (votersMissingRedeemer.length > 0) {
       return yield* Effect.fail(
         new TransactionBuilderError({
           message:
-            `Redeemer required for ${plutusVotersMissingRedeemer.length} Plutus-script voter(s): ` +
-            `${plutusVotersMissingRedeemer.join(", ")}. ` +
-            `Native-script voters do not need a redeemer. Attach the native script via .attachScript() ` +
-            `(or provide it through a reference input) so it can be classified correctly.`,
-          cause: plutusVotersMissingRedeemer
+            `Redeemer required for ${votersMissingRedeemer.length} non-native-script voter(s): ` +
+            `${votersMissingRedeemer.join(", ")}. ` +
+            `If a voter is a native (multisig) script, attach it via .attachScript() ` +
+            `(or provide it through a reference input) so it is recognized and no redeemer is needed; ` +
+            `if it is a Plutus script, supply a redeemer.`,
+          cause: votersMissingRedeemer
         })
       )
     }

--- a/packages/evolution/src/sdk/builders/internal/txBuilder.ts
+++ b/packages/evolution/src/sdk/builders/internal/txBuilder.ts
@@ -342,7 +342,7 @@ export const validateVoterRedeemers: Effect.Effect<void, TransactionBuilderError
     }
 
     if (nativeVoterRedeemerKeys.length > 0) {
-      yield* Effect.logWarning(
+      yield* Effect.logDebug(
         `[Vote] Ignoring redeemer(s) supplied for native-script voter(s): ${nativeVoterRedeemerKeys.join(", ")}. ` +
           `Native scripts are satisfied by vkey witnesses, not redeemers.`
       )

--- a/packages/evolution/src/sdk/builders/operations/Vote.ts
+++ b/packages/evolution/src/sdk/builders/operations/Vote.ts
@@ -74,16 +74,6 @@ export const createVoteProgram = (params: VoteParams): Effect.Effect<void, Trans
       )
     }
 
-    // 4. If script voters exist but no redeemer, fail
-    if (scriptVoters.size > 0 && !params.redeemer) {
-      return yield* Effect.fail(
-        new TransactionBuilderError({
-          message: "Redeemer required for script-controlled voters",
-          cause: Array.from(scriptVoters)
-        })
-      )
-    }
-
     // 5. Update state: merge voting procedures and track redeemers
     yield* Ref.update(ctx, (state) => {
       // Merge voting procedures

--- a/packages/evolution/test/TxBuilder.NativeScriptVote.test.ts
+++ b/packages/evolution/test/TxBuilder.NativeScriptVote.test.ts
@@ -11,6 +11,7 @@ import type { TxBuilderConfig } from "../src/sdk/builders/TransactionBuilder.js"
 import { makeTxBuilder } from "../src/sdk/builders/TransactionBuilder.js"
 import { mainnet } from "../src/sdk/client/index.js"
 import * as TransactionHash from "../src/TransactionHash.js"
+import * as CoreUTxO from "../src/UTxO.js"
 import * as VotingProcedures from "../src/VotingProcedures.js"
 import { createCoreTestUtxo } from "./utils/utxo-helpers.js"
 
@@ -162,5 +163,88 @@ describe("TxBuilder NativeScript Vote (native-script DRep)", () => {
           protocolParameters: PROTOCOL_PARAMS
         })
     ).rejects.toThrow(/[Rr]edeemer required/)
+  })
+
+  it("sizes the fee for the native script's threshold signers", async () => {
+    const { script, voter } = makeMultisigDRep()
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    const signBuilder = await makeTxBuilder(baseConfig)
+      .vote({ votingProcedures })
+      .attachScript({ script })
+      .build({
+        changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        availableUtxos: [walletUtxo],
+        protocolParameters: PROTOCOL_PARAMS
+      })
+
+    // Fee estimation uses fake witnesses; a 2-of-3 native DRep contributes 2 dummy
+    // vkey witnesses (its threshold) on top of the 1 wallet-input signer.
+    const fakeTx = await signBuilder.toTransactionWithFakeWitnesses()
+    expect(fakeTx.witnessSet.vkeyWitnesses?.length ?? 0).toBeGreaterThanOrEqual(3)
+  })
+
+  it("classifies a native voter whose script is provided via a reference input", async () => {
+    const { script, voter } = makeMultisigDRep()
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    // The native script is supplied via a reference input rather than .attachScript().
+    const refUtxo = new CoreUTxO.UTxO({
+      transactionId: TransactionHash.fromHex("b".repeat(64)),
+      index: 0n,
+      address: CoreAddress.fromBech32(CHANGE_ADDRESS),
+      assets: CoreAssets.fromLovelace(5_000_000n),
+      scriptRef: script
+    })
+
+    const signBuilder = await makeTxBuilder(baseConfig)
+      .vote({ votingProcedures })
+      .readFrom({ referenceInputs: [refUtxo] })
+      .build({
+        changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        availableUtxos: [walletUtxo],
+        protocolParameters: PROTOCOL_PARAMS
+      })
+
+    const tx = await signBuilder.toTransaction()
+    expect(tx.witnessSet.redeemers).toBeUndefined()
+    expect(tx.body.referenceInputs?.length ?? 0).toBeGreaterThan(0)
+  })
+
+  it("allows a native-script Constitutional Committee voter without a redeemer", async () => {
+    const { script, scriptHash } = makeMultisigDRep()
+    const voter = new VotingProcedures.ConstitutionalCommitteeVoter({ credential: scriptHash })
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    const signBuilder = await makeTxBuilder(baseConfig)
+      .vote({ votingProcedures })
+      .attachScript({ script })
+      .build({
+        changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        availableUtxos: [walletUtxo],
+        protocolParameters: PROTOCOL_PARAMS
+      })
+
+    const tx = await signBuilder.toTransaction()
+    expect(tx.witnessSet.nativeScripts?.length ?? 0).toBeGreaterThan(0)
+    expect(tx.witnessSet.redeemers).toBeUndefined()
   })
 })

--- a/packages/evolution/test/TxBuilder.NativeScriptVote.test.ts
+++ b/packages/evolution/test/TxBuilder.NativeScriptVote.test.ts
@@ -90,7 +90,7 @@ describe("TxBuilder NativeScript Vote (native-script DRep)", () => {
       lovelace: 100_000_000n
     })
 
-    // attachScript intentionally placed AFTER vote — the redeemer requirement is resolved
+    // attachScript intentionally placed AFTER vote; the redeemer requirement is resolved
     // at build time, so call order must not matter.
     const signBuilder = await makeTxBuilder(baseConfig)
       .vote({ votingProcedures })
@@ -135,7 +135,7 @@ describe("TxBuilder NativeScript Vote (native-script DRep)", () => {
 
     const tx = await signBuilder.toTransaction()
     expect(tx.witnessSet.nativeScripts?.length ?? 0).toBeGreaterThan(0)
-    // The spurious redeemer must be pruned — native scripts use signatures, not redeemers.
+    // The spurious redeemer must be pruned; native scripts use signatures, not redeemers.
     expect(tx.witnessSet.redeemers).toBeUndefined()
     expect(tx.body.scriptDataHash).toBeUndefined()
   })

--- a/packages/evolution/test/TxBuilder.NativeScriptVote.test.ts
+++ b/packages/evolution/test/TxBuilder.NativeScriptVote.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "@effect/vitest"
+
+import * as CoreAddress from "../src/Address.js"
+import * as CoreAssets from "../src/Assets.js"
+import * as Data from "../src/Data.js"
+import * as DRep from "../src/DRep.js"
+import * as GovernanceAction from "../src/GovernanceAction.js"
+import * as NativeScripts from "../src/NativeScripts.js"
+import * as ScriptHash from "../src/ScriptHash.js"
+import type { TxBuilderConfig } from "../src/sdk/builders/TransactionBuilder.js"
+import { makeTxBuilder } from "../src/sdk/builders/TransactionBuilder.js"
+import { mainnet } from "../src/sdk/client/index.js"
+import * as TransactionHash from "../src/TransactionHash.js"
+import * as VotingProcedures from "../src/VotingProcedures.js"
+import { createCoreTestUtxo } from "./utils/utxo-helpers.js"
+
+const PROTOCOL_PARAMS = {
+  minFeeCoefficient: 44n,
+  minFeeConstant: 155_381n,
+  coinsPerUtxoByte: 4_310n,
+  maxTxSize: 16_384
+}
+
+const CHANGE_ADDRESS =
+  "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae"
+
+const baseConfig = { chain: mainnet } satisfies TxBuilderConfig
+
+// A governance action being voted on.
+const govActionId = new GovernanceAction.GovActionId({
+  transactionId: new TransactionHash.TransactionHash({ hash: new Uint8Array(32).fill(0xcd) }),
+  govActionIndex: 0n
+})
+
+const yesProcedure = new VotingProcedures.VotingProcedure({ vote: VotingProcedures.yes(), anchor: null })
+
+// Build a 2-of-3 native (multisig) script and the DRep voter it backs.
+const makeMultisigDRep = () => {
+  const keyHashes = [0xaa, 0xbb, 0xcc].map((b) => new Uint8Array(28).fill(b))
+  const script = NativeScripts.makeScriptNOfK(
+    2n,
+    keyHashes.map((kh) => NativeScripts.makeScriptPubKey(kh).script)
+  )
+  const scriptHash = ScriptHash.fromScript(script)
+  const voter = new VotingProcedures.DRepVoter({ drep: DRep.fromScriptHash(scriptHash) })
+  return { script, scriptHash, voter }
+}
+
+describe("TxBuilder NativeScript Vote (native-script DRep)", () => {
+  it("builds a vote from a native-script DRep with no redeemer", async () => {
+    const { script, voter } = makeMultisigDRep()
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    const signBuilder = await makeTxBuilder(baseConfig)
+      .vote({ votingProcedures })
+      .attachScript({ script })
+      .build({
+        changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        availableUtxos: [walletUtxo],
+        protocolParameters: PROTOCOL_PARAMS
+      })
+
+    const tx = await signBuilder.toTransaction()
+
+    // The native script must be in the witness set.
+    expect(tx.witnessSet.nativeScripts?.length ?? 0).toBeGreaterThan(0)
+    // No redeemers / scriptDataHash / collateral for native-script voting.
+    expect(tx.witnessSet.redeemers).toBeUndefined()
+    expect(tx.body.scriptDataHash).toBeUndefined()
+    expect(tx.body.collateralInputs).toBeUndefined()
+    expect(tx.body.votingProcedures).toBeDefined()
+  })
+
+  it("builds when .vote() is called before .attachScript() (order-independent)", async () => {
+    const { script, voter } = makeMultisigDRep()
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    // attachScript intentionally placed AFTER vote — the redeemer requirement is resolved
+    // at build time, so call order must not matter.
+    const signBuilder = await makeTxBuilder(baseConfig)
+      .vote({ votingProcedures })
+      .payToAddress({
+        address: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        assets: CoreAssets.fromLovelace(2_000_000n)
+      })
+      .attachScript({ script })
+      .build({
+        changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        availableUtxos: [walletUtxo],
+        protocolParameters: PROTOCOL_PARAMS
+      })
+
+    const tx = await signBuilder.toTransaction()
+    expect(tx.witnessSet.nativeScripts?.length ?? 0).toBeGreaterThan(0)
+    expect(tx.witnessSet.redeemers).toBeUndefined()
+  })
+
+  it("ignores a redeemer supplied for a native-script voter (no redeemer emitted)", async () => {
+    const { script, voter } = makeMultisigDRep()
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    const signBuilder = await makeTxBuilder(baseConfig)
+      .vote({
+        votingProcedures,
+        redeemer: new Data.Constr({ index: 0n, fields: [] })
+      })
+      .attachScript({ script })
+      .build({
+        changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+        availableUtxos: [walletUtxo],
+        protocolParameters: PROTOCOL_PARAMS
+      })
+
+    const tx = await signBuilder.toTransaction()
+    expect(tx.witnessSet.nativeScripts?.length ?? 0).toBeGreaterThan(0)
+    // The spurious redeemer must be pruned — native scripts use signatures, not redeemers.
+    expect(tx.witnessSet.redeemers).toBeUndefined()
+    expect(tx.body.scriptDataHash).toBeUndefined()
+  })
+
+  it("still rejects a Plutus-script voter when no redeemer is provided", async () => {
+    // A script-hash DRep whose script is NOT a native script (never attached / not resolvable
+    // as native) must still require a redeemer.
+    const plutusScriptHash = ScriptHash.fromHex("11".repeat(28))
+    const voter = new VotingProcedures.DRepVoter({ drep: DRep.fromScriptHash(plutusScriptHash) })
+    const votingProcedures = VotingProcedures.singleVote(voter, govActionId, yesProcedure)
+
+    const walletUtxo = createCoreTestUtxo({
+      transactionId: "a".repeat(64),
+      index: 0n,
+      address: CHANGE_ADDRESS,
+      lovelace: 100_000_000n
+    })
+
+    await expect(
+      makeTxBuilder(baseConfig)
+        .vote({ votingProcedures })
+        .build({
+          changeAddress: CoreAddress.fromBech32(CHANGE_ADDRESS),
+          availableUtxos: [walletUtxo],
+          protocolParameters: PROTOCOL_PARAMS
+        })
+    ).rejects.toThrow(/[Rr]edeemer required/)
+  })
+})


### PR DESCRIPTION
Fixes #425

  ## Problem
  `TxBuilder.vote()` rejected native-script (multisig) DRep voters, demanding a Plutus
  redeemer.
  
  ## Fix
  The native-vs-Plutus distinction can only be made once the voter's script is
  attached/referenced, and builder programs run with no defined order (`Effect.all`,
  unbounded concurrency) — so the check can't be eager. Moved it to build time:

  - **Vote.ts** — removed the eager "redeemer required" rejection; kept redeemer
  tracking.
  - **txBuilder.ts** — added `validateVoterRedeemers`: classifies each voter's script
  (native vs Plutus), requires a redeemer only for Plutus voters, and prunes any
  spurious redeemer on a native voter.
  - **build.ts** — runs the validator after all programs populate state.
  
  ## Tests
  New `TxBuilder.NativeScriptVote.test.ts`: 2-of-3 native DRep vote with no redeemer,
  call-order independence, redeemer pruning, and that Plutus voters still require a
  redeemer.