### PR TITLE
fix(provider): correct Maestro host and submit endpoint

### DIFF
--- a/.changeset/maestro-submit-endpoint.md
+++ b/.changeset/maestro-submit-endpoint.md
@@ -1,5 +1,5 @@
 ---
-"@evolution-sdk/evolution": patch
+"@evolution-sdk/evolution": minor
 ---
 
 Fix the Maestro provider host and transaction submission endpoint. Submission posted to `/submit` (or `/turbo/submit` with `turboSubmit`), but Maestro accepts transactions through its Transaction Manager API at `/txmanager` and `/txmanager/turbosubmit`, so every submit returned a 404. The pre-configured `mainnet`, `preprod`, and `preview` constructors also pointed at `*.api.maestro.org`, which does not serve the Cardano API; they now use `https://{network}.gomaestro-api.org/v1`, affecting every request the provider makes, not just submission.

--- a/.changeset/maestro-submit-endpoint.md
+++ b/.changeset/maestro-submit-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Fix the Maestro provider host and transaction submission endpoint. Submission posted to `/submit` (or `/turbo/submit` with `turboSubmit`), but Maestro accepts transactions through its Transaction Manager API at `/txmanager` and `/txmanager/turbosubmit`, so every submit returned a 404. The pre-configured `mainnet`, `preprod`, and `preview` constructors also pointed at `*.api.maestro.org`, which does not serve the Cardano API; they now use `https://{network}.gomaestro-api.org/v1`, affecting every request the provider makes, not just submission.

--- a/packages/evolution/src/sdk/provider/Maestro.ts
+++ b/packages/evolution/src/sdk/provider/Maestro.ts
@@ -73,7 +73,7 @@ export class MaestroProvider implements Provider {
  * @category constructors
  */
 export const mainnet = (apiKey: string, turboSubmit: boolean = false): MaestroProvider =>
-  new MaestroProvider("https://api.maestro.org/v1", apiKey, turboSubmit)
+  new MaestroProvider("https://mainnet.gomaestro-api.org/v1", apiKey, turboSubmit)
 
 /**
  * Pre-configured Maestro provider for Cardano preprod testnet.
@@ -82,7 +82,7 @@ export const mainnet = (apiKey: string, turboSubmit: boolean = false): MaestroPr
  * @category constructors
  */
 export const preprod = (apiKey: string, turboSubmit: boolean = false): MaestroProvider =>
-  new MaestroProvider("https://preprod.api.maestro.org/v1", apiKey, turboSubmit)
+  new MaestroProvider("https://preprod.gomaestro-api.org/v1", apiKey, turboSubmit)
 
 /**
  * Pre-configured Maestro provider for Cardano preview testnet.
@@ -91,4 +91,4 @@ export const preprod = (apiKey: string, turboSubmit: boolean = false): MaestroPr
  * @category constructors
  */
 export const preview = (apiKey: string, turboSubmit: boolean = false): MaestroProvider =>
-  new MaestroProvider("https://preview.api.maestro.org/v1", apiKey, turboSubmit)
+  new MaestroProvider("https://preview.gomaestro-api.org/v1", apiKey, turboSubmit)

--- a/packages/evolution/src/sdk/provider/internal/MaestroEffect.ts
+++ b/packages/evolution/src/sdk/provider/internal/MaestroEffect.ts
@@ -190,7 +190,7 @@ export const getDelegation = (baseUrl: string, apiKey: string) => (rewardAddress
  */
 export const submitTx = (baseUrl: string, apiKey: string, turboSubmit?: boolean) => (tx: Transaction.Transaction) =>
   Effect.gen(function* () {
-    const endpoint = turboSubmit ? "/turbo/submit" : "/submit"
+    const endpoint = turboSubmit ? "/txmanager/turbosubmit" : "/txmanager"
 
     // Convert Transaction to CBOR bytes for submission
     const txBytes = Transaction.toCBORBytes(tx)


### PR DESCRIPTION
## Problem

Two wrong URLs make the Maestro provider unusable.

**1. Submit endpoint (`MaestroEffect.ts:193`)**

```ts
const endpoint = turboSubmit ? "/turbo/submit" : "/submit"
```

Maestro accepts transactions through its Transaction Manager API — `POST /txmanager`, or `POST /txmanager/turbosubmit` for turbo. Both branches above 404, so no transaction could ever be submitted. Maestro's own curl example uses `https://preprod.gomaestro-api.org/v1/txmanager/turbosubmit`, and the lucid-evolution provider this was ported from builds the same two paths.

**2. Base URLs (`Maestro.ts`)**

`mainnet`/`preprod`/`preview` pointed at `*.api.maestro.org`, which does not serve the Cardano API — it answers `{"message":"Cannot GET /","error":"Not Found"}` from an unrelated Express app. Maestro's OpenAPI specs list exactly three Cardano servers, `https://{mainnet,preprod,preview}.gomaestro-api.org/v1`, and Mesh's Maestro provider builds the same base URL. This affects every request the provider makes, not just submission.

`test/provider/providers.test.ts:36` already defaults to `https://preprod.gomaestro-api.org/v1`, so the constructors were the outlier.

## Fix

- `/submit` → `/txmanager`, `/turbo/submit` → `/txmanager/turbosubmit`
- constructors → `https://{mainnet,preprod,preview}.gomaestro-api.org/v1`

The rest of the submit path was already correct: `HttpUtils.postUint8Array` sends `Content-Type: application/cbor`, and its plain-text fallback handles Maestro's unquoted tx-hash response.

## Verification

`pnpm type-check` passes, ESLint clean on both files, Prettier clean (the 4 files it flags in that directory are pre-existing drift in files this PR doesn't touch). The Maestro conformance suite skips without `MAESTRO_PREPROD_KEY`, so the corrected endpoints have **not** been exercised against a live API — worth one manual run by someone with a key before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
