### PR TITLE
ci: run workflows on node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: 📦 Install dependencies
@@ -47,7 +47,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: 📦 Install dependencies
@@ -69,7 +69,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: 📦 Install dependencies
@@ -91,7 +91,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: 📦 Install dependencies

--- a/.github/workflows/dependabot-fix-lockfile.yml
+++ b/.github/workflows/dependabot-fix-lockfile.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Regenerate lockfile
         run: pnpm install --lockfile-only --no-frozen-lockfile --ignore-scripts

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: ⎔ Install Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: 📦 Install pnpm
         uses: pnpm/action-setup@v6.0.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org/'
 


### PR DESCRIPTION
## Problem

The Release workflow has been failing since npm 12 shipped — [run 30454254372](https://github.com/IntersectMBO/evolution-sdk/actions/runs/30454254372/job/90583671986):

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`release.yml` pins `node-version: 20` but runs `npm install -g npm@latest`, which is needed for trusted publishing (npm >= 11.5.1). npm 12 dropped Node 20, which went EOL in April 2026. The job now dies before installing dependencies, so nothing publishes. The last green release was 2026-06-29; the run above is simply the first push to `main` since npm 12 landed.

## Fix

`node-version: 20` -> `22` in `release.yml`, and in `ci.yml` (4 jobs), `docs.yml`, and `dependabot-fix-lockfile.yml` so the release job builds and tests on the same runtime CI exercises. `post-release-to-x.yml` was already on 22.

`setup-node` with `node-version: 22` resolves to 22.23.1, satisfying npm 12's `^22.22.2`. Node 24 would also work; 22 is the smaller step from the Node 20 this code has been tested on.

## Verification

Ran locally on Node 22 (v22.21.1): `turbo run build` 6/6, `turbo run lint type-check` 9/9, and `@evolution-sdk/evolution` tests 1130 passed / 71 skipped.

`@evolution-sdk/devnet` tests fail in my environment ("No test files found" plus an image-inspection error pulling `ghcr.io/intersectmbo/cardano-node:10.5.1`). That is local-environment-specific — this diff touches only workflow YAML and cannot affect test behavior, and the same suite passed in the last green release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
