### PR TITLE
fix(ci): unblock npm publish and revert unintended version bump

### DIFF
--- a/.changeset/maestro-submit-endpoint.md
+++ b/.changeset/maestro-submit-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Fix the Maestro provider host and transaction submission endpoint. Submission posted to `/submit` (or `/turbo/submit` with `turboSubmit`), but Maestro accepts transactions through its Transaction Manager API at `/txmanager` and `/txmanager/turbosubmit`, so every submit returned a 404. The pre-configured `mainnet`, `preprod`, and `preview` constructors also pointed at `*.api.maestro.org`, which does not serve the Cardano API; they now use `https://{network}.gomaestro-api.org/v1`, affecting every request the provider makes, not just submission.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: 📦 Update npm to latest (required for trusted publishing)
-        run: npm install -g npm@latest
+      # npm 12 rejects the --no-git-checks flag that changesets passes when publishing
+      # a pnpm workspace, so pin to the 11.x line (>= 11.5.1 is required for trusted publishing)
+      - name: 📦 Update npm (required for trusted publishing)
+        run: npm install -g npm@11
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
@@ -49,7 +51,6 @@ jobs:
       - name: 🦋 Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1.9.0
-        continue-on-error: true
         with:
           # This uses our custom publish script that builds before publishing
           publish: pnpm changeset-publish

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,13 +1,5 @@
 # docs
 
-## 0.0.54
-
-### Patch Changes
-
-- Updated dependencies [[`9e45103`](https://github.com/IntersectMBO/evolution-sdk/commit/9e451039688818c4beb7395eb500daf04b8d65da)]:
-  - @evolution-sdk/evolution@0.6.0
-  - @evolution-sdk/devnet@4.0.0
-
 ## 0.0.53
 
 ### Patch Changes

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.0.54",
+  "version": "0.0.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/with-vite-react/CHANGELOG.md
+++ b/examples/with-vite-react/CHANGELOG.md
@@ -1,12 +1,5 @@
 # evolution-vite-react-example
 
-## 0.1.32
-
-### Patch Changes
-
-- Updated dependencies [[`9e45103`](https://github.com/IntersectMBO/evolution-sdk/commit/9e451039688818c4beb7395eb500daf04b8d65da)]:
-  - @evolution-sdk/evolution@0.6.0
-
 ## 0.1.31
 
 ### Patch Changes

--- a/examples/with-vite-react/package.json
+++ b/examples/with-vite-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evolution-vite-react-example",
-  "version": "0.1.32",
+  "version": "0.1.31",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/aiken-uplc/CHANGELOG.md
+++ b/packages/aiken-uplc/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @evolution-sdk/aiken-uplc
 
-## 3.0.0
-
-### Patch Changes
-
-- Updated dependencies [[`9e45103`](https://github.com/IntersectMBO/evolution-sdk/commit/9e451039688818c4beb7395eb500daf04b8d65da)]:
-  - @evolution-sdk/evolution@0.6.0
-
 ## 2.0.11
 
 ### Patch Changes

--- a/packages/aiken-uplc/package.json
+++ b/packages/aiken-uplc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolution-sdk/aiken-uplc",
-  "version": "3.0.0",
+  "version": "2.0.11",
   "description": "Aiken UPLC evaluator for Evolution SDK with WASM-based local script evaluation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/evolution-devnet/CHANGELOG.md
+++ b/packages/evolution-devnet/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @evolution-sdk/devnet
 
-## 4.0.0
-
-### Patch Changes
-
-- Updated dependencies [[`9e45103`](https://github.com/IntersectMBO/evolution-sdk/commit/9e451039688818c4beb7395eb500daf04b8d65da)]:
-  - @evolution-sdk/evolution@0.6.0
-  - @evolution-sdk/aiken-uplc@3.0.0
-  - @evolution-sdk/scalus-uplc@3.0.0
-
 ## 3.0.12
 
 ### Patch Changes

--- a/packages/evolution-devnet/package.json
+++ b/packages/evolution-devnet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolution-sdk/devnet",
-  "version": "4.0.0",
+  "version": "3.0.12",
   "description": "Local Cardano devnet for testing and development with Docker",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/evolution/CHANGELOG.md
+++ b/packages/evolution/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evolution-sdk/evolution
 
-## 0.6.0
-
-### Minor Changes
-
-- [#474](https://github.com/IntersectMBO/evolution-sdk/pull/474) [`9e45103`](https://github.com/IntersectMBO/evolution-sdk/commit/9e451039688818c4beb7395eb500daf04b8d65da) Thanks [@hadelive](https://github.com/hadelive)! - Fix the Maestro provider host and transaction submission endpoint. Submission posted to `/submit` (or `/turbo/submit` with `turboSubmit`), but Maestro accepts transactions through its Transaction Manager API at `/txmanager` and `/txmanager/turbosubmit`, so every submit returned a 404. The pre-configured `mainnet`, `preprod`, and `preview` constructors also pointed at `*.api.maestro.org`, which does not serve the Cardano API; they now use `https://{network}.gomaestro-api.org/v1`, affecting every request the provider makes, not just submission.
-
 ## 0.5.11
 
 ### Patch Changes

--- a/packages/evolution/package.json
+++ b/packages/evolution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolution-sdk/evolution",
-  "version": "0.6.0",
+  "version": "0.5.11",
   "description": "A modern TypeScript SDK for Cardano blockchain development",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scalus-uplc/CHANGELOG.md
+++ b/packages/scalus-uplc/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @evolution-sdk/scalus-uplc
 
-## 3.0.0
-
-### Patch Changes
-
-- Updated dependencies [[`9e45103`](https://github.com/IntersectMBO/evolution-sdk/commit/9e451039688818c4beb7395eb500daf04b8d65da)]:
-  - @evolution-sdk/evolution@0.6.0
-
 ## 2.0.11
 
 ### Patch Changes

--- a/packages/scalus-uplc/package.json
+++ b/packages/scalus-uplc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@evolution-sdk/scalus-uplc",
-  "version": "3.0.0",
+  "version": "2.0.11",
   "description": "Scalus UPLC evaluator adapter for Evolution SDK",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Two problems, one PR — because merging them separately would publish the versions we are trying to take back.

## 1. Publish is broken under npm 12

[Run 30457694907](https://github.com/IntersectMBO/evolution-sdk/actions/runs/30457694907) reported success but published nothing:

```
🦋 error an error occurred while publishing @evolution-sdk/evolution: EUNKNOWNCONFIG Unknown cli flag:
🦋 error   - --git-checks
##[error]Publish command exited with code 1
```

`@changesets/cli` 2.31.1 detects the pnpm workspace (root `packageManager: pnpm@9.0.0`) and appends `--no-git-checks` to the publish command (`changesets-cli.esm.js:851`). That flag reaches `npm publish`, and npm 12 turned unknown CLI flags into a hard error — npm prints it as `--git-checks` because it strips the `no-` prefix. The last green publish, on 2026-06-29, ran npm 11.18.0; npm 12.0.0 shipped 2026-07-08.

Pinned to `npm@11` (resolves 11.18.0, still >= 11.5.1 for trusted publishing). Upgrading pnpm to 10.x is the longer-term fix and deserves its own PR.

Also removed `continue-on-error: true` from the changesets step. That flag is why this went unnoticed: the job stayed green while all four packages failed to publish.

## 2. Revert the version bump — patch, not minor

The Maestro changeset was marked `minor`, which cascaded further than intended. `devnet`, `aiken-uplc`, and `scalus-uplc` all declare `@evolution-sdk/evolution` as a `peerDependency` (`workspace:*`), and changesets escalates peer-dependents to a **major** bump when the peer dep gets more than a patch. Replaying `changeset version` both ways:

| package | as merged (minor) | as patch |
| --- | --- | --- |
| `@evolution-sdk/evolution` | 0.6.0 | 0.5.12 |
| `@evolution-sdk/devnet` | 4.0.0 | 3.0.13 |
| `@evolution-sdk/aiken-uplc` | 3.0.0 | 2.0.12 |
| `@evolution-sdk/scalus-uplc` | 3.0.0 | 2.0.12 |

One provider bugfix should not force three major releases. This reverts `588ebb37` and restores the changeset as `patch`. Nothing was published at 0.6.0, so there is no yanked version to work around.

## After merge

The release run will open a fresh version PR at 0.5.12 / 3.0.13 / 2.0.12 / 2.0.12; merging that one publishes.

## Verification

Versions confirmed back at 0.5.11 / 3.0.12 / 2.0.11 / 2.0.11 with the changeset restored as `patch`, and the 0.5.12 numbers above came from an actual `changeset version` run on a scratch worktree. The publish path itself cannot be exercised outside a release run — the next one is the real test, and it will now fail loudly instead of silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
