### PR TITLE
fix(github): point CODEOWNERS at current maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,18 @@
 # Global owners
-* @no-witness-labs
+* @solidsnakedev
 
 # Evolution SDK core
-/packages/evolution/ @no-witness-labs
+/packages/evolution/ @solidsnakedev
 
 # Documentation
-/docs/ @no-witness-labs
-/README.md @no-witness-labs
+/docs/ @solidsnakedev
+/README.md @solidsnakedev
 
 # CI/CD and GitHub configuration
-/.github/ @no-witness-labs
-/.changeset/ @no-witness-labs
+/.github/ @solidsnakedev
+/.changeset/ @solidsnakedev
 
 # Package configuration
-/package.json @no-witness-labs
-/turbo.json @no-witness-labs
-/tsconfig*.json @no-witness-labs
+/package.json @solidsnakedev
+/turbo.json @solidsnakedev
+/tsconfig*.json @solidsnakedev


### PR DESCRIPTION
`.github/CODEOWNERS` points every path at `@no-witness-labs`, which is an organization handle — not a user or team — and has no write access to this repo. GitHub rejects all 9 entries:

      GET /repos/IntersectMBO/evolution-sdk/codeowners/errors
      → 9 × "Unknown owner on line N: make sure @no-witness-labs exists and has write access to the repository"

  The file has been inert since it was added, this repoints it at `@solidsnakedev`, who has admin access and resolves as a valid owner.