### PR TITLE
fix(multiasset): look assets up by structural equality

### DIFF
--- a/.changeset/multiasset-structural-lookup.md
+++ b/.changeset/multiasset-structural-lookup.md
@@ -1,0 +1,5 @@
+---
+"@evolution-sdk/evolution": patch
+---
+
+Look assets up by structural equality in `MultiAsset` and compare quantities directly in `Value.geq`. `getAsset`, `hasAsset`, `getAssetsByPolicy`, and `MultiAsset.subtract` read the map with `Map.get`, which compares `PolicyId` and `AssetName` by reference. Keys decoded from CBOR are fresh instances, so every lookup against decoded data missed: `getAsset` returned `undefined` for an asset that was present, `hasAsset` returned `false`, `getAssetsByPolicy` returned an empty array, and `subtract` returned the minuend unchanged instead of reducing it. `Value.geq` inferred sufficiency from `subtract` not throwing, so it reported that a value covered an amount it did not hold. These functions now match keys the way `addAsset` already did, and `geq` compares the coin and each requested quantity directly.

--- a/packages/evolution/src/MultiAsset.ts
+++ b/packages/evolution/src/MultiAsset.ts
@@ -52,6 +52,24 @@ const mapHash = <K, V>(map: Map<K, V>): number => {
 }
 
 /**
+ * Look a key up by structural equality.
+ *
+ * PolicyId and AssetName are classes, so `Map.get` compares them by reference and
+ * misses keys decoded separately from the ones being searched for.
+ *
+ * @since 2.0.0
+ * @category utilities
+ */
+const findByEquality = <K, V>(map: Map<K, V>, key: K): V | undefined => {
+  for (const [candidate, value] of map.entries()) {
+    if (Equal.equals(candidate, key)) {
+      return value
+    }
+  }
+  return undefined
+}
+
+/**
  * Schema for inner asset map (asset_name => bigint).
  *
  * This is a **base type** with no constraints. Values can be positive,
@@ -290,10 +308,9 @@ export const addAsset = (
  * @category transformation
  */
 export const getAsset = (multiAsset: MultiAsset, policyId: PolicyId.PolicyId, assetName: AssetName.AssetName) => {
-  const assetMap = multiAsset.map.get(policyId)
+  const assetMap = findByEquality(multiAsset.map, policyId)
   if (assetMap !== undefined) {
-    const amount = assetMap.get(assetName)
-    return amount !== undefined ? amount : undefined
+    return findByEquality(assetMap, assetName)
   }
   return undefined
 }
@@ -328,7 +345,7 @@ export const getPolicyIds = (multiAsset: MultiAsset): Array<PolicyId.PolicyId> =
  * @category transformation
  */
 export const getAssetsByPolicy = (multiAsset: MultiAsset, policyId: PolicyId.PolicyId) => {
-  const assetMap = multiAsset.map.get(policyId)
+  const assetMap = findByEquality(multiAsset.map, policyId)
   return assetMap !== undefined ? Array.from(assetMap.entries()) : []
 }
 
@@ -553,7 +570,7 @@ export const subtract = (a: MultiAsset, b: MultiAsset): MultiAsset => {
 
   // Start with all assets from a
   for (const [policyId, assetMapA] of a.map.entries()) {
-    const assetMapB = b.map.get(policyId)
+    const assetMapB = findByEquality(b.map, policyId)
 
     if (assetMapB === undefined) {
       // No assets to subtract for this policy, keep all
@@ -563,7 +580,7 @@ export const subtract = (a: MultiAsset, b: MultiAsset): MultiAsset => {
       const newAssetMap = new Map<AssetName.AssetName, bigint>()
 
       for (const [assetName, amountA] of assetMapA.entries()) {
-        const amountB = assetMapB.get(assetName)
+        const amountB = findByEquality(assetMapB, assetName)
 
         if (amountB === undefined) {
           // No amount to subtract, keep the original

--- a/packages/evolution/src/Value.ts
+++ b/packages/evolution/src/Value.ts
@@ -224,12 +224,25 @@ export const subtract = (a: Value, b: Value): Value => {
  * @category ordering
  */
 export const geq = (a: Value, b: Value): boolean => {
-  try {
-    subtract(a, b)
-    return true
-  } catch {
+  if (a.coin < b.coin) {
     return false
   }
+
+  if (b._tag === "OnlyCoin") {
+    return true
+  }
+
+  const held = a._tag === "OnlyCoin" ? undefined : a.assets
+  for (const [policyId, assetMap] of b.assets.map.entries()) {
+    for (const [assetName, wanted] of assetMap.entries()) {
+      const have = held === undefined ? undefined : MultiAsset.getAsset(held, policyId, assetName)
+      if (have === undefined || have < wanted) {
+        return false
+      }
+    }
+  }
+
+  return true
 }
 
 /**

--- a/packages/evolution/test/MultiAsset.structuralLookup.test.ts
+++ b/packages/evolution/test/MultiAsset.structuralLookup.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import * as AssetName from "../src/AssetName.js"
+import * as MultiAsset from "../src/MultiAsset.js"
+import * as PolicyId from "../src/PolicyId.js"
+import * as Value from "../src/Value.js"
+
+// PolicyId and AssetName are classes, so a plain Map compares them by reference.
+// Each call here builds fresh key instances, which is what happens when one value
+// is decoded from the chain and the other is constructed locally.
+const policyId = () => PolicyId.fromHex("0".repeat(56))
+const assetName = () => AssetName.fromHex("4d79546f6b656e")
+
+describe("MultiAsset lookups with reference-distinct keys", () => {
+  it("getAsset finds an asset held under an equal but distinct key", () => {
+    const held = MultiAsset.singleton(policyId(), assetName(), 5n)
+    expect(MultiAsset.getAsset(held, policyId(), assetName())).toBe(5n)
+  })
+
+  it("hasAsset reports an asset held under an equal but distinct key", () => {
+    const held = MultiAsset.singleton(policyId(), assetName(), 5n)
+    expect(MultiAsset.hasAsset(held, policyId(), assetName())).toBe(true)
+  })
+
+  it("getAssetsByPolicy lists assets under an equal but distinct policy id", () => {
+    const held = MultiAsset.singleton(policyId(), assetName(), 5n)
+    expect(MultiAsset.getAssetsByPolicy(held, policyId())).toHaveLength(1)
+  })
+
+  it("subtract cancels equal amounts held under distinct keys", () => {
+    const held = MultiAsset.singleton(policyId(), assetName(), 5n)
+    const same = MultiAsset.singleton(policyId(), assetName(), 5n)
+    expect(() => MultiAsset.subtract(held, same)).toThrow()
+  })
+
+  it("subtract reduces the amount rather than leaving it untouched", () => {
+    const held = MultiAsset.singleton(policyId(), assetName(), 5n)
+    const two = MultiAsset.singleton(policyId(), assetName(), 2n)
+    const rest = MultiAsset.subtract(held, two)
+    expect(MultiAsset.getAsset(rest, policyId(), assetName())).toBe(3n)
+  })
+})
+
+describe("Value.geq with reference-distinct keys", () => {
+  const withAssets = (amount: bigint) => Value.withAssets(2_000_000n, MultiAsset.singleton(policyId(), assetName(), amount))
+
+  it("reports insufficient assets as insufficient", () => {
+    expect(Value.geq(withAssets(5n), withAssets(100n))).toBe(false)
+  })
+
+  it("reports sufficient assets as sufficient", () => {
+    expect(Value.geq(withAssets(100n), withAssets(5n))).toBe(true)
+  })
+
+  it("reports an equal amount as sufficient", () => {
+    expect(Value.geq(withAssets(5n), withAssets(5n))).toBe(true)
+  })
+
+  it("reports a missing asset as insufficient", () => {
+    expect(Value.geq(Value.onlyCoin(2_000_000n), withAssets(1n))).toBe(false)
+  })
+
+  it("compares lovelace", () => {
+    expect(Value.geq(Value.onlyCoin(1_000_000n), Value.onlyCoin(2_000_000n))).toBe(false)
+    expect(Value.geq(Value.onlyCoin(2_000_000n), Value.onlyCoin(1_000_000n))).toBe(true)
+  })
+})


### PR DESCRIPTION
`MultiAsset.getAsset`, `hasAsset`, `getAssetsByPolicy`, and `subtract` read the asset map with `Map.get`, which compares `PolicyId` and `AssetName` by reference. Keys decoded from CBOR are fresh instances, so every lookup against decoded data missed: `getAsset` returned `undefined` for an asset that was present, `getAssetsByPolicy` returned an empty array, and `subtract` returned the minuend unchanged. `Value.geq` inferred sufficiency from `subtract` not throwing, so it reported that a value covered an amount it did not hold.

These four functions now match keys the way `addAsset` already did, through a shared `findByEquality` helper, and `geq` compares the coin and each requested quantity directly instead of catching an exception. A value holding 5 of a token now correctly reports that it does not cover 100.

Closes #390